### PR TITLE
Add initialize core API type definitions

### DIFF
--- a/src/interfaces/decorator.interface.ts
+++ b/src/interfaces/decorator.interface.ts
@@ -1,0 +1,35 @@
+import type { ApiProperty } from '.'
+
+type MetadataPropertiesKeys = 'body' | 'query' | 'params' | 'response'
+
+export type DefaultMetadataProperties = {
+  [P in MetadataPropertiesKeys]?: string
+}
+
+export interface EndpointDecoratorMetadata<P extends DefaultMetadataProperties> {
+  description: string
+  request?: {
+    body?: {
+      type: string
+      properties: P['body'] extends string ? Record<P['body'], ApiProperty> : never
+      required?: string[]
+    }
+    query?: {
+      type: string
+      properties: P['query'] extends string ? Record<P['query'], ApiProperty> : never
+      required?: string[]
+    }
+    params?: {
+      type: string
+      properties: P['params'] extends string ? Record<P['params'], ApiProperty> : never
+      required?: string[]
+    }
+  }
+  response?: {
+    type: string
+    properties?: P['response'] extends string ? Record<P['response'], ApiProperty> : never
+    example?: P['response'] extends string ? Record<P['response'], any> | Array<Record<P['response'], any>> : never
+  }
+  deprecated?: boolean
+  tags?: string[]
+}

--- a/src/interfaces/documentation.interface.ts
+++ b/src/interfaces/documentation.interface.ts
@@ -1,0 +1,27 @@
+import type { ApiEndpoint } from './endpoint.interface'
+
+export interface ApiController {
+  controllerName: string
+  basePath: string
+  description?: string
+  tags?: string[]
+  endpoints: ApiEndpoint[]
+}
+
+export interface ApiDocumentation {
+  info: {
+    title: string
+    description?: string
+    version: string
+    contact?: {
+      name?: string
+      email?: string
+      url?: string
+    }
+  }
+  servers: Array<{
+    url: string
+    description?: string
+  }>
+  controllers: ApiController[]
+}

--- a/src/interfaces/endpoint.interface.ts
+++ b/src/interfaces/endpoint.interface.ts
@@ -1,0 +1,20 @@
+import type { HttpMethod, ApiRequest, ApiResponse } from '.'
+
+export interface ApiEndpoint {
+  path: string
+  method: HttpMethod
+  name: string
+  description: string
+  deprecated?: boolean
+  tags?: string[]
+  request?: ApiRequest
+  response: ApiResponse
+}
+
+export interface ApiEndpointMetadata {
+  description: string
+  requestExample?: any
+  responseExample?: any
+  deprecated?: boolean
+  tags?: string[]
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,0 +1,34 @@
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+
+export interface ApiProperty {
+  type: string
+  description: string
+  required?: boolean
+  example?: any
+  enum?: string[]
+  items?: ApiProperty
+}
+
+export interface ApiParameters {
+  type: string
+  properties: Record<string, ApiProperty>
+  required?: string[]
+}
+
+export interface ApiRequest {
+  body?: ApiParameters
+  query?: ApiParameters
+  params?: ApiParameters
+  headers?: ApiParameters
+}
+
+export interface ApiResponse {
+  type: string
+  description?: string
+  example?: any
+  properties?: Record<string, ApiProperty>
+}
+
+export * from './endpoint.interface'
+export * from './documentation.interface'
+export * from './decorator.interface'


### PR DESCRIPTION
This pull request introduces several interfaces to improve the structure and documentation of API endpoints. The changes include defining types for metadata properties, API endpoints, controllers, and documentation.

#7 interface

The most important changes include:

### Interface Definitions:

* [`src/interfaces/decorator.interface.ts`](diffhunk://#diff-fdca2ab58e5c74cf32110041671f52f858e7eb35f20cd2d06761b8f6a41dbeb8R1-R35): Added `DefaultMetadataProperties` type and `EndpointDecoratorMetadata` interface to define metadata for API endpoint decorators.

* [`src/interfaces/endpoint.interface.ts`](diffhunk://#diff-68549b615faf99c6a7aa00327eb205777f07702b5e46eeaffc3015c81d85eefdR1-R20): Added `ApiEndpoint` and `ApiEndpointMetadata` interfaces to describe the structure and metadata of API endpoints.

* [`src/interfaces/documentation.interface.ts`](diffhunk://#diff-69fe94285b2d2bb113abbbd015b54c829884a40074097cfd45fba90dd795b46aR1-R27): Added `ApiController` and `ApiDocumentation` interfaces to define the structure of API controllers and overall documentation.

### Type Exports:

* [`src/interfaces/index.ts`](diffhunk://#diff-2433a58dd5b382f3ef0faf44d5ab97bf79428a0a1452d72934c9ca3c77a237bcR1-R34): Added type definitions for `HttpMethod`, `ApiProperty`, `ApiParameters`, `ApiRequest`, and `ApiResponse`, and exported all interfaces from the module.