### PR TITLE
Add implement API documentation decorators

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,19 +33,20 @@
   ],
   "peerDependencies": {
     "@nestjs/common": "^10.0.0",
-    "@nestjs/core": "^10.0.0",
-    "reflect-metadata": "^0.1.13"
+    "@nestjs/core": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.0.0",
     "@types/node": "^22.13.4",
+    "@types/reflect-metadata": "^0.1.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
-    "prettier": "^3.0.0",
-    "eslint": "^8.0.0",
     "jest": "^29.0.0",
+    "prettier": "^3.0.0",
+    "reflect-metadata": "^0.2.2",
     "ts-jest": "^29.0.0",
     "typescript": "^5.7.3"
   },

--- a/src/decorators/controller.decorator.ts
+++ b/src/decorators/controller.decorator.ts
@@ -1,0 +1,11 @@
+interface ApiDocsControllerMetadata {
+  description?: string
+  tags?: string[]
+}
+
+export const ApiDocsController = (metadata: ApiDocsControllerMetadata): ClassDecorator => {
+  return (target: any) => {
+    Reflect.defineMetadata('api:controller', metadata, target)
+    return target
+  }
+}

--- a/src/decorators/endpoint.decorator.ts
+++ b/src/decorators/endpoint.decorator.ts
@@ -1,0 +1,9 @@
+import 'reflect-metadata'
+import type { EndpointDecoratorMetadata, DefaultMetadataProperties } from '../interfaces'
+
+export const ApiDocsEndpoint = <P extends DefaultMetadataProperties>(metadata: EndpointDecoratorMetadata<P>): MethodDecorator => {
+  return (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) => {
+    Reflect.defineMetadata('api:endpoint', metadata, target, propertyKey)
+    return descriptor
+  }
+}

--- a/src/decorators/endpoint.decorator.ts
+++ b/src/decorators/endpoint.decorator.ts
@@ -1,4 +1,3 @@
-import 'reflect-metadata'
 import type { EndpointDecoratorMetadata, DefaultMetadataProperties } from '../interfaces'
 
 export const ApiDocsEndpoint = <P extends DefaultMetadataProperties>(metadata: EndpointDecoratorMetadata<P>): MethodDecorator => {

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,0 +1,1 @@
+export * from './endpoint.decorator'

--- a/src/decorators/parameters.decorator.ts
+++ b/src/decorators/parameters.decorator.ts
@@ -1,0 +1,18 @@
+interface ApiDocsParameterMetadata {
+  type: string
+  properties: Record<string, any>
+  required?: string[]
+}
+
+const createParameterDecorator = (metadataKey: string) => {
+  return (metadata: ApiDocsParameterMetadata): ParameterDecorator => {
+    return (target: any, propertyKey: string | symbol) => {
+      const existingMetadata = Reflect.getMetadata(metadataKey, target, propertyKey) || {}
+      Reflect.defineMetadata(metadataKey, { ...existingMetadata, ...metadata }, target, propertyKey)
+    }
+  }
+}
+
+export const ApiDocsBody = createParameterDecorator('api:body')
+export const ApiDocsQuery = createParameterDecorator('api:query')
+export const ApiDocsParam = createParameterDecorator('api:param')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import 'reflect-metadata'
+
 export interface TestInterface {
   name: string
   value: number

--- a/yarn.lock
+++ b/yarn.lock
@@ -688,6 +688,13 @@
   dependencies:
     undici-types "~6.20.0"
 
+"@types/reflect-metadata@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@types/reflect-metadata/-/reflect-metadata-0.1.0.tgz#592805bdf6d63dd7229773218afeba37ac2eab16"
+  integrity sha512-bXltFLY3qhzCnVYP5iUpeSICagQ8rc9K2liS+8M0lBcz54BHs3O6W5UvqespVSuebo1BXLi+/y9ioELAW9SC2A==
+  dependencies:
+    reflect-metadata "*"
+
 "@types/semver@^7.5.0":
   version "7.5.8"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
@@ -2438,6 +2445,11 @@ react-is@^18.0.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+reflect-metadata@*, reflect-metadata@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz#400c845b6cba87a21f2c65c4aeb158f4fa4d9c5b"
+  integrity sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
This pull request introduces several new decorators and updates dependencies in the project. The most important changes include the addition of new decorators for API documentation and updates to the `package.json` dependencies.

### New Decorators for API Documentation:

* [`src/decorators/controller.decorator.ts`](diffhunk://#diff-ebd054a1f0b4fb6dbe2960fc89586e2f9390522cb04c31489d5b93064deb9578R1-R11): Added `ApiDocsController` decorator to define metadata for API controllers.
* [`src/decorators/endpoint.decorator.ts`](diffhunk://#diff-3d26692d176c1cfcacc37d0016aa3f723a4e648cb48e01223f6465a421f4155cR1-R8): Added `ApiDocsEndpoint` decorator to define metadata for API endpoints.
* [`src/decorators/parameters.decorator.ts`](diffhunk://#diff-b5af1ab8218f8132b25a9d1c8bfe4a051205d31a960a7f3cea4bbfcd1e56d241R1-R18): Added `ApiDocsBody`, `ApiDocsQuery`, and `ApiDocsParam` decorators to define metadata for API parameters.
* [`src/decorators/index.ts`](diffhunk://#diff-ff731a6595150a46863141c7777ad96afb0cf539bfc3da315d428fc1450f7837R1): Exported the new `endpoint.decorator` module.

### Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L36-R49): Updated `devDependencies` and `peerDependencies`, including adding `@types/reflect-metadata` and updating `reflect-metadata` to version `^0.2.2`.

### Other Changes:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1-R2): Imported `reflect-metadata` to ensure metadata reflection capabilities are available.