### PR TITLE
Add error constants and default config

### DIFF
--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -1,0 +1,17 @@
+export const ERROR_MESSAGES = {
+  INVALID_APP: 'Invalid NestJS application instance provided',
+  NO_DISCOVERY_SERVICE: 'DiscoveryService not found in application instance',
+
+  DIRECTORY_CREATE_FAILED: 'Failed to create directory',
+  FILE_WRITE_FAILED: 'Failed to write file',
+  INVALID_PATH: 'Invalid file path provided',
+
+  NO_CONTROLLER_METADATA: 'No controller metadata found',
+  NO_ENDPOINT_METADATA: 'No endpoint metadata found',
+  INVALID_METHOD: 'Invalid HTTP method',
+
+  INVALID_CONFIG: 'Invalid configuration provided',
+  MISSING_REQUIRED_CONFIG: 'Missing required configuration options'
+} as const
+
+export type ErrorMessage = keyof typeof ERROR_MESSAGES

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_CONFIG = {
+  VERSION: '1.0.0',
+  TITLE: 'API Documentation',
+  DESCRIPTION: 'Generated API documentation by doke',
+  ENCODINGS: 'utf-8',
+  OUTPUT_PATH: 'api-docs',
+  JSON_INDENT: 2
+} as const
+
+export * from './metadata.keys'
+export * from './errors'

--- a/src/constants/metadata.keys.ts
+++ b/src/constants/metadata.keys.ts
@@ -1,0 +1,14 @@
+export const METADATA_KEYS = {
+  PATH: 'path',
+  METHOD: 'method',
+
+  CONTROLLER: 'api:controller',
+  ENDPOINT: 'api:endpoint',
+
+  BODY: 'api:body',
+  QUERY: 'api:query',
+  PARAM: 'api:param',
+  HEADERS: 'api:headers'
+} as const
+
+export type MetadataKey = keyof typeof METADATA_KEYS

--- a/src/decorators/controller.decorator.ts
+++ b/src/decorators/controller.decorator.ts
@@ -1,3 +1,5 @@
+import { METADATA_KEYS } from 'src/constants'
+
 interface ApiDocsControllerMetadata {
   description?: string
   tags?: string[]
@@ -5,7 +7,7 @@ interface ApiDocsControllerMetadata {
 
 export const ApiDocsController = (metadata: ApiDocsControllerMetadata): ClassDecorator => {
   return (target: any) => {
-    Reflect.defineMetadata('api:controller', metadata, target)
+    Reflect.defineMetadata(METADATA_KEYS.CONTROLLER, metadata, target)
     return target
   }
 }

--- a/src/decorators/endpoint.decorator.ts
+++ b/src/decorators/endpoint.decorator.ts
@@ -1,8 +1,9 @@
+import { METADATA_KEYS } from 'src/constants'
 import type { EndpointDecoratorMetadata, DefaultMetadataProperties } from '../interfaces'
 
 export const ApiDocsEndpoint = <P extends DefaultMetadataProperties>(metadata: EndpointDecoratorMetadata<P>): MethodDecorator => {
   return (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) => {
-    Reflect.defineMetadata('api:endpoint', metadata, target, propertyKey)
+    Reflect.defineMetadata(METADATA_KEYS.ENDPOINT, metadata, target, propertyKey)
     return descriptor
   }
 }

--- a/src/decorators/parameters.decorator.ts
+++ b/src/decorators/parameters.decorator.ts
@@ -1,3 +1,5 @@
+import { METADATA_KEYS } from 'src/constants'
+
 interface ApiDocsParameterMetadata {
   type: string
   properties: Record<string, any>
@@ -13,6 +15,6 @@ const createParameterDecorator = (metadataKey: string) => {
   }
 }
 
-export const ApiDocsBody = createParameterDecorator('api:body')
-export const ApiDocsQuery = createParameterDecorator('api:query')
-export const ApiDocsParam = createParameterDecorator('api:param')
+export const ApiDocsBody = createParameterDecorator(METADATA_KEYS.BODY)
+export const ApiDocsQuery = createParameterDecorator(METADATA_KEYS.QUERY)
+export const ApiDocsParam = createParameterDecorator(METADATA_KEYS.PARAM)


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of constants and metadata keys, as well as to streamline the use of these constants across the codebase. The most significant changes involve the centralization of error messages, default configurations, and metadata keys, as well as the modification of decorators to utilize these centralized constants.

#7 

Centralization of constants:

* [`src/constants/errors.ts`](diffhunk://#diff-9c14ee41d4d86a50064154daa7a7b057ae1a638cbee4bfa4f53abd57d4464e04R1-R17): Added a centralized `ERROR_MESSAGES` object containing various error messages, and defined a corresponding `ErrorMessage` type.
* [`src/constants/index.ts`](diffhunk://#diff-e1d6888195cb2d996149fde20e8cf0413a478aee630031ff8b7c9c1b64bbcd88R1-R11): Introduced a `DEFAULT_CONFIG` object with default configuration values and re-exported constants from other files.
* [`src/constants/metadata.keys.ts`](diffhunk://#diff-987d915bed027ba5600aa50406786046ced6e08330de29c17430d92e777b83f5R1-R14): Added a centralized `METADATA_KEYS` object for metadata keys and defined a corresponding `MetadataKey` type.

Modification of decorators:

* [`src/decorators/controller.decorator.ts`](diffhunk://#diff-ebd054a1f0b4fb6dbe2960fc89586e2f9390522cb04c31489d5b93064deb9578R1-R10): Updated the `ApiDocsController` decorator to use `METADATA_KEYS.CONTROLLER` instead of a hardcoded string.
* [`src/decorators/endpoint.decorator.ts`](diffhunk://#diff-3d26692d176c1cfcacc37d0016aa3f723a4e648cb48e01223f6465a421f4155cR1-R6): Updated the `ApiDocsEndpoint` decorator to use `METADATA_KEYS.ENDPOINT` instead of a hardcoded string.
* [`src/decorators/parameters.decorator.ts`](diffhunk://#diff-b5af1ab8218f8132b25a9d1c8bfe4a051205d31a960a7f3cea4bbfcd1e56d241R1-R2): Updated parameter decorators to use `METADATA_KEYS` constants instead of hardcoded strings. [[1]](diffhunk://#diff-b5af1ab8218f8132b25a9d1c8bfe4a051205d31a960a7f3cea4bbfcd1e56d241R1-R2) [[2]](diffhunk://#diff-b5af1ab8218f8132b25a9d1c8bfe4a051205d31a960a7f3cea4bbfcd1e56d241L16-R20)