### PR TITLE
Add MetadataExtractor class for extracting metadata from controllers …

### DIFF
--- a/src/interfaces/endpoint.interface.ts
+++ b/src/interfaces/endpoint.interface.ts
@@ -13,6 +13,7 @@ export interface ApiEndpoint {
 
 export interface ApiEndpointMetadata {
   description: string
+  response: ApiResponse
   requestExample?: any
   responseExample?: any
   deprecated?: boolean

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,4 +1,4 @@
-export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'ALL' | 'OPTIONS' | 'HEAD'
 
 export interface ApiProperty {
   type: string

--- a/src/utils/metadata-extractor.ts
+++ b/src/utils/metadata-extractor.ts
@@ -1,0 +1,84 @@
+import { METADATA_KEYS } from '../constants'
+import type { ApiEndpoint, ApiEndpointMetadata, ApiController, HttpMethod } from '../interfaces'
+
+export class MetadataExtractor {
+  static extractControllerMetadata(controller: any): Pick<ApiController, 'description' | 'tags'> | null {
+    const metadata = Reflect.getMetadata(METADATA_KEYS.CONTROLLER, controller)
+    if (!metadata) return null
+
+    return {
+      description: metadata.description,
+      tags: metadata.tags
+    }
+  }
+
+  static extractControllerPath(controller: any): string | null {
+    return Reflect.getMetadata(METADATA_KEYS.PATH, controller)
+  }
+
+  static extractEndpointMetadata(prototype: any, methodName: string): ApiEndpoint | null {
+    const metadata: ApiEndpointMetadata = Reflect.getMetadata(METADATA_KEYS.ENDPOINT, prototype, methodName)
+    if (!metadata) return null
+
+    const path = Reflect.getMetadata(METADATA_KEYS.PATH, prototype[methodName])
+    const methodValue = Reflect.getMetadata(METADATA_KEYS.METHOD, prototype[methodName])
+
+    if (!path || methodValue === undefined) return null
+
+    const method = this.convertMethodValueToString(methodValue)
+    if (!method) return null
+
+    const request = this.extractRequestMetadata(prototype, methodName)
+
+    return {
+      path,
+      method,
+      name: methodName,
+      description: metadata.description,
+      deprecated: metadata.deprecated,
+      tags: metadata.tags,
+      request: Object.keys(request).length > 0 ? request : undefined,
+      response: metadata.response
+    }
+  }
+
+  private static extractRequestMetadata(prototype: any, methodName: string) {
+    const request: Record<string, any> = {}
+
+    const bodyMetadata = Reflect.getMetadata(METADATA_KEYS.BODY, prototype, methodName)
+    if (bodyMetadata) {
+      request.body = bodyMetadata
+    }
+
+    const queryMetadata = Reflect.getMetadata(METADATA_KEYS.QUERY, prototype, methodName)
+    if (queryMetadata) {
+      request.query = queryMetadata
+    }
+
+    const paramMetadata = Reflect.getMetadata(METADATA_KEYS.PARAM, prototype, methodName)
+    if (paramMetadata) {
+      request.params = paramMetadata
+    }
+
+    return request
+  }
+
+  static extractMethodNames(prototype: any): string[] {
+    return Object.getOwnPropertyNames(prototype).filter((prop) => prop !== 'constructor' && typeof prototype[prop] === 'function')
+  }
+
+  private static convertMethodValueToString(methodValue: number): HttpMethod | null {
+    const methodMap: Record<number, HttpMethod> = {
+      0: 'GET',
+      1: 'POST',
+      2: 'PUT',
+      3: 'DELETE',
+      4: 'PATCH',
+      5: 'ALL',
+      6: 'OPTIONS',
+      7: 'HEAD'
+    }
+
+    return methodMap[methodValue] || null
+  }
+}


### PR DESCRIPTION
This pull request introduces several changes to the API metadata handling and extraction. The most important changes include adding new HTTP methods, updating the `ApiEndpointMetadata` interface, and creating a new `MetadataExtractor` utility class.

### Updates to API Metadata Handling:

* [`src/interfaces/endpoint.interface.ts`](diffhunk://#diff-68549b615faf99c6a7aa00327eb205777f07702b5e46eeaffc3015c81d85eefdR16): Added a `response` property to the `ApiEndpointMetadata` interface.
* [`src/interfaces/index.ts`](diffhunk://#diff-2433a58dd5b382f3ef0faf44d5ab97bf79428a0a1452d72934c9ca3c77a237bcL1-R1): Expanded the `HttpMethod` type to include `ALL`, `OPTIONS`, and `HEAD`.

### Creation of MetadataExtractor Utility:

* [`src/utils/metadata-extractor.ts`](diffhunk://#diff-fe9762174fea24cabe4b7ec2e206a6a1f322d2eb2ce6fec95cd710f7b228e29cR1-R84): Introduced a new `MetadataExtractor` class that includes methods for extracting metadata from controllers and endpoints, such as `extractControllerMetadata`, `extractControllerPath`, `extractEndpointMetadata`, `extractRequestMetadata`, `extractMethodNames`, and `convertMethodValueToString`.…and endpoints