### PR TITLE
Add TypeValidator class for validating API endpoint metadata

### DIFF
--- a/src/interfaces/endpoint.interface.ts
+++ b/src/interfaces/endpoint.interface.ts
@@ -8,12 +8,13 @@ export interface ApiEndpoint {
   deprecated?: boolean
   tags?: string[]
   request?: ApiRequest
-  response: ApiResponse
+  response?: ApiResponse
 }
 
 export interface ApiEndpointMetadata {
   description: string
-  response: ApiResponse
+  request?: ApiRequest
+  response?: ApiResponse
   requestExample?: any
   responseExample?: any
   deprecated?: boolean

--- a/src/utils/metadata-extractor.ts
+++ b/src/utils/metadata-extractor.ts
@@ -37,7 +37,7 @@ export class MetadataExtractor {
       description: metadata.description,
       deprecated: metadata.deprecated,
       tags: metadata.tags,
-      request: Object.keys(request).length > 0 ? request : undefined,
+      request,
       response: metadata.response
     }
   }

--- a/src/utils/type-validator.ts
+++ b/src/utils/type-validator.ts
@@ -1,0 +1,93 @@
+import { ERROR_MESSAGES } from 'src/constants'
+import type { HttpMethod, ApiEndpointMetadata, ApiProperty, ApiParameters, ApiRequest, ApiResponse } from 'src/interfaces'
+
+export class TypeValidator {
+  private static readonly VALID_HTTP_METHODS: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'ALL', 'OPTIONS', 'HEAD']
+  private static readonly VALID_PARAMETER_TYPES = ['string', 'number', 'boolean', 'object', 'array']
+
+  static isValidHttpMethod(method: string): method is HttpMethod {
+    return this.VALID_HTTP_METHODS.includes(method as HttpMethod)
+  }
+
+  static isValidPropertyType(type: string): boolean {
+    return this.VALID_PARAMETER_TYPES.includes(type.toLowerCase())
+  }
+
+  static validateEndpointMetadata(metadata: ApiEndpointMetadata): void {
+    if (!metadata.description) {
+      throw new Error(`${ERROR_MESSAGES.NO_ENDPOINT_METADATA}: Missing description`)
+    }
+
+    if (metadata.response) {
+      this.validateResponse(metadata.response)
+    }
+
+    if (metadata.request) {
+      this.validateRequest(metadata.request)
+    }
+  }
+
+  static validateRequest(request: ApiRequest): void {
+    if (request.body) this.validateParameters(request.body, 'body')
+    if (request.query) this.validateParameters(request.query, 'query')
+    if (request.params) this.validateParameters(request.params, 'params')
+    if (request.headers) this.validateParameters(request.headers, 'headers')
+  }
+
+  static validateResponse(response: ApiResponse): void {
+    if (!response.type) {
+      throw new Error(`${ERROR_MESSAGES.INVALID_CONFIG}: Response must have a type`)
+    }
+
+    if (!this.isValidPropertyType(response.type)) {
+      throw new Error(`${ERROR_MESSAGES.INVALID_CONFIG}: Invalid response type '${response.type}'`)
+    }
+
+    if (response.properties) {
+      Object.entries(response.properties).forEach(([key, property]) => {
+        this.validateProperty(property, `response.${key}`)
+      })
+    }
+  }
+
+  static validateParameters(parameters: ApiParameters, location: string): void {
+    if (!parameters.type) {
+      throw new Error(`${ERROR_MESSAGES.INVALID_CONFIG}: ${location} parameters must have a type`)
+    }
+
+    if (!parameters.properties) {
+      throw new Error(`${ERROR_MESSAGES.INVALID_CONFIG}: ${location} parameters must have properties`)
+    }
+
+    Object.entries(parameters.properties).forEach(([key, property]) => {
+      this.validateProperty(property, `${location}.${key}`)
+    })
+
+    if (parameters.required) {
+      const propertyKeys = Object.keys(parameters.properties)
+      parameters.required.forEach((requiredKey) => {
+        if (!propertyKeys.includes(requiredKey)) {
+          throw new Error(`${ERROR_MESSAGES.INVALID_CONFIG}: Required property '${requiredKey}' not found in ${location} properties`)
+        }
+      })
+    }
+  }
+
+  static validateProperty(property: ApiProperty, path: string): void {
+    if (!property.type) {
+      throw new Error(`${ERROR_MESSAGES.INVALID_CONFIG}: Missing type for property at ${path}`)
+    }
+
+    if (!this.isValidPropertyType(property.type)) {
+      throw new Error(`${ERROR_MESSAGES.INVALID_CONFIG}: Invalid type '${property.type}' for property at ${path}`)
+    }
+
+    if (!property.description) {
+      throw new Error(`${ERROR_MESSAGES.INVALID_CONFIG}: Missing description for property at ${path}`)
+    }
+
+    if (property.items) {
+      this.validateProperty(property.items, `${path}[]`)
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces several important changes to the API endpoint interface and adds a new utility class for validating types. The most significant changes include making the `response` field optional in the `ApiEndpoint` interface, simplifying the `MetadataExtractor` class, and adding comprehensive validation logic in the new `TypeValidator` class.

### Changes to API endpoint interface:

* [`src/interfaces/endpoint.interface.ts`](diffhunk://#diff-68549b615faf99c6a7aa00327eb205777f07702b5e46eeaffc3015c81d85eefdL11-R17): Made the `response` field optional in the `ApiEndpoint` interface and `ApiEndpointMetadata` interface. This change allows endpoints to be defined without a mandatory response object.

### Simplification of MetadataExtractor class:

* [`src/utils/metadata-extractor.ts`](diffhunk://#diff-fe9762174fea24cabe4b7ec2e206a6a1f322d2eb2ce6fec95cd710f7b228e29cL40-R40): Simplified the `MetadataExtractor` class by removing the conditional assignment for the `request` field.

### Addition of TypeValidator class:

* [`src/utils/type-validator.ts`](diffhunk://#diff-06e4210f8bd7b7828b7ddc681d7dca873078f12c89ac0a592698d859ca49ab5aR1-R93): Introduced a new `TypeValidator` class that includes methods for validating HTTP methods, property types, endpoint metadata, requests, responses, and parameters. This class ensures that the API configurations adhere to the expected structure and types.