### PR TITLE
Add API documentation generator, path metadata-extractor in index.ts

### DIFF
--- a/src/generators/api-docs.generator.ts
+++ b/src/generators/api-docs.generator.ts
@@ -1,0 +1,75 @@
+import { INestApplication } from '@nestjs/common'
+import { DiscoveryService } from '@nestjs/core'
+import { MetadataExtractor } from 'src/utils/metadata-extractor'
+import { FileManager } from 'src/utils/file-manager'
+import { ERROR_MESSAGES } from 'src/constants'
+import type { ApiController } from 'src/interfaces'
+
+interface ProjectMetadata {
+  name: string
+  description: string
+  version: string
+  routes: string[]
+}
+
+export class ApiDocsGenerator {
+  private readonly docs: ApiController[]
+  private readonly projectMetadata: ProjectMetadata
+  private readonly fileManager: FileManager
+
+  constructor(metadata: Omit<ProjectMetadata, 'routes'>, outputPath: string) {
+    this.docs = []
+    this.projectMetadata = { ...metadata, routes: [] }
+    this.fileManager = new FileManager(outputPath)
+  }
+
+  async generateDocs(app: INestApplication) {
+    const discoveryService = app.get(DiscoveryService)
+    if (!discoveryService) {
+      throw new Error(ERROR_MESSAGES.NO_DISCOVERY_SERVICE)
+    }
+
+    const controllers = discoveryService.getControllers()
+
+    for (const wrapper of controllers) {
+      if (!wrapper.instance || !wrapper.metatype) continue
+
+      const prototype = Object.getPrototypeOf(wrapper.instance)
+      const controllerPath = MetadataExtractor.extractControllerPath(wrapper.metatype)
+      if (!controllerPath) continue
+
+      const controllerMetadata = MetadataExtractor.extractControllerMetadata(wrapper.metatype)
+      const methodNames = MetadataExtractor.extractMethodNames(prototype)
+
+      const endpoints = methodNames
+        .map((methodName) => MetadataExtractor.extractEndpointMetadata(prototype, methodName))
+        .filter((endpoint): endpoint is NonNullable<typeof endpoint> => endpoint !== null)
+
+      if (endpoints.length === 0) continue
+
+      this.projectMetadata.routes.push(controllerPath)
+
+      this.docs.push({
+        controllerName: wrapper.metatype.name,
+        basePath: controllerPath,
+        description: controllerMetadata?.description,
+        tags: controllerMetadata?.tags,
+        endpoints
+      })
+    }
+
+    await this.fileManager.createDirectoryStructure()
+    await this.saveProjectMetadata()
+    await this.saveRouteDocs()
+  }
+
+  private async saveProjectMetadata() {
+    await this.fileManager.saveJson('projects', this.projectMetadata)
+  }
+
+  private async saveRouteDocs() {
+    for (const doc of this.docs) {
+      await this.fileManager.saveJson(`routes/${doc.basePath}`, doc)
+    }
+  }
+}

--- a/src/generators/index.ts
+++ b/src/generators/index.ts
@@ -1,0 +1,1 @@
+export * from './api-docs.generator'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './file-manager'
+export * from './metadata-extractor'


### PR DESCRIPTION
This pull request introduces a new `ApiDocsGenerator` class to generate API documentation for a NestJS application. It also includes necessary imports and exports to support this functionality.

### New functionality:

* [`src/generators/api-docs.generator.ts`](diffhunk://#diff-ac99ae691595cb9c45796b9cc63c6451cf00887d8aa328bca30f27e94716f08bR1-R75): Added the `ApiDocsGenerator` class to generate API documentation by extracting metadata from controllers and saving it to JSON files.

### Supporting changes:

* [`src/generators/index.ts`](diffhunk://#diff-480d36a296821a122d6072387c7596eef4c123210e134f6d78d30d13472b2f82R1): Exported the `ApiDocsGenerator` from the generators module.
* [`src/utils/index.ts`](diffhunk://#diff-6147e3c1761df71fd40952dbcbac388a45f80b8c318f367ef41048351a2c0c99R2): Exported the `MetadataExtractor` utility to facilitate metadata extraction in the `ApiDocsGenerator` class.