### PR TITLE
Refactor API Docs Generator and Discovery Service imports

### DIFF
--- a/src/generators/api-docs.generator.ts
+++ b/src/generators/api-docs.generator.ts
@@ -1,9 +1,8 @@
 import type { ApiController } from '../interfaces'
-
+import { DiscoveryService } from '@nestjs/core'
 import { MetadataExtractor } from '../utils/metadata-extractor'
 import { FileManager } from '../utils/file-manager'
 import { ERROR_MESSAGES } from '../constants'
-import { DiscoveryService } from '@nestjs/core'
 
 interface ProjectMetadata {
   name: string
@@ -23,51 +22,78 @@ export class ApiDocsGenerator {
     this.fileManager = new FileManager(outputPath, targetFolder)
   }
 
-  async generateDocs(discoveryService: DiscoveryService) {
+  async generateDocs(discoveryService: DiscoveryService): Promise<void> {
+    this.validateDiscoveryService(discoveryService)
+    const data = await this.getControllersInfo(discoveryService)
+    this.storeControllersInfo(data)
+    await this.saveDocumentation()
+  }
+
+  private validateDiscoveryService(discoveryService: DiscoveryService): void {
     if (!discoveryService) {
       throw new Error(ERROR_MESSAGES.NO_DISCOVERY_SERVICE)
     }
-
-    const controllers = discoveryService.getControllers()
-
-    for (const wrapper of controllers) {
-      if (!wrapper.instance || !wrapper.metatype) continue
-
-      const prototype = Object.getPrototypeOf(wrapper.instance)
-      const controllerPath = MetadataExtractor.extractControllerPath(wrapper.metatype)
-      if (!controllerPath) continue
-
-      const controllerMetadata = MetadataExtractor.extractControllerMetadata(wrapper.metatype)
-      const methodNames = MetadataExtractor.extractMethodNames(prototype)
-      const endpoints = methodNames
-        .map((methodName) => MetadataExtractor.extractEndpointMetadata(prototype, methodName))
-        .filter((endpoint): endpoint is NonNullable<typeof endpoint> => endpoint !== null)
-
-      if (endpoints.length === 0) continue
-
-      this.projectMetadata.routes.push(controllerPath)
-
-      this.docs.push({
-        controllerName: wrapper.metatype.name,
-        basePath: controllerPath,
-        description: controllerMetadata?.description,
-        tags: controllerMetadata?.tags,
-        endpoints
-      })
-    }
-
-    await this.fileManager.createDirectoryStructure()
-    await this.saveProjectMetadata()
-    await this.saveRouteDocs()
   }
 
-  private async saveProjectMetadata() {
+  private storeControllersInfo(data: ApiController[]) {
+    for (const info of data) {
+      this.projectMetadata.routes.push(info.basePath)
+      this.docs.push(info)
+    }
+  }
+
+  private extractControllerInfo(wrapper: { instance: any; metatype: any }): ApiController | null {
+    if (!this.isValidWrapper(wrapper)) return null
+
+    const prototype = Object.getPrototypeOf(wrapper.instance)
+    const controllerPath = MetadataExtractor.extractControllerPath(wrapper.metatype)
+    if (!controllerPath) return null
+
+    const endpoints = this.extractEndpoints(prototype)
+    if (endpoints.length === 0) return null
+
+    const controllerMetadata = MetadataExtractor.extractControllerMetadata(wrapper.metatype)
+
+    return {
+      controllerName: wrapper.metatype.name,
+      basePath: controllerPath,
+      description: controllerMetadata?.description,
+      tags: controllerMetadata?.tags,
+      endpoints
+    }
+  }
+
+  private isValidWrapper(wrapper: { instance: any; metatype: any }): boolean {
+    return !!(wrapper.instance && wrapper.metatype)
+  }
+
+  private extractEndpoints(prototype: any): ApiController['endpoints'] {
+    const methodNames = MetadataExtractor.extractMethodNames(prototype)
+    return methodNames
+      .map((methodName) => MetadataExtractor.extractEndpointMetadata(prototype, methodName))
+      .filter((endpoint): endpoint is NonNullable<typeof endpoint> => endpoint !== null)
+  }
+
+  private async getControllersInfo(discoveryService: DiscoveryService) {
+    const controllers = discoveryService.getControllers()
+    const extractions: ApiController[] = []
+    for (const wrapper of controllers) {
+      const controllerInfo = this.extractControllerInfo(wrapper)
+      if (controllerInfo) extractions.push(controllerInfo)
+    }
+    return extractions
+  }
+
+  private async saveDocumentation(): Promise<void> {
+    await this.fileManager.createDirectoryStructure()
+    await Promise.all([this.saveProjectMetadata(), this.saveRouteDocs()])
+  }
+
+  private async saveProjectMetadata(): Promise<void> {
     await this.fileManager.saveJson('projects', this.projectMetadata)
   }
 
-  private async saveRouteDocs() {
-    for (const doc of this.docs) {
-      await this.fileManager.saveJson(`routes/${doc.basePath}`, doc)
-    }
+  private async saveRouteDocs(): Promise<void> {
+    await Promise.all(this.docs.map((doc) => this.fileManager.saveJson(`routes/${doc.basePath}`, doc)))
   }
 }

--- a/src/generators/api-docs.generator.ts
+++ b/src/generators/api-docs.generator.ts
@@ -39,7 +39,6 @@ export class ApiDocsGenerator {
 
       const controllerMetadata = MetadataExtractor.extractControllerMetadata(wrapper.metatype)
       const methodNames = MetadataExtractor.extractMethodNames(prototype)
-
       const endpoints = methodNames
         .map((methodName) => MetadataExtractor.extractEndpointMetadata(prototype, methodName))
         .filter((endpoint): endpoint is NonNullable<typeof endpoint> => endpoint !== null)

--- a/src/generators/api-docs.generator.ts
+++ b/src/generators/api-docs.generator.ts
@@ -1,8 +1,9 @@
-import { INestApplication } from '@nestjs/common'
+import type { ApiController } from '../interfaces'
+
 import { MetadataExtractor } from '../utils/metadata-extractor'
 import { FileManager } from '../utils/file-manager'
 import { ERROR_MESSAGES } from '../constants'
-import type { ApiController } from '../interfaces'
+import { DiscoveryService } from '@nestjs/core'
 
 interface ProjectMetadata {
   name: string
@@ -22,8 +23,7 @@ export class ApiDocsGenerator {
     this.fileManager = new FileManager(outputPath, targetFolder)
   }
 
-  async generateDocs(app: INestApplication<any>, Test: any) {
-    const discoveryService = app.get(Test)
+  async generateDocs(discoveryService: DiscoveryService) {
     if (!discoveryService) {
       throw new Error(ERROR_MESSAGES.NO_DISCOVERY_SERVICE)
     }
@@ -39,8 +39,6 @@ export class ApiDocsGenerator {
 
       const controllerMetadata = MetadataExtractor.extractControllerMetadata(wrapper.metatype)
       const methodNames = MetadataExtractor.extractMethodNames(prototype)
-
-      // console.log(methodNames.map((methodName) => MetadataExtractor.extractEndpointMetadata(prototype, methodName)))
 
       const endpoints = methodNames
         .map((methodName) => MetadataExtractor.extractEndpointMetadata(prototype, methodName))

--- a/src/utils/metadata-extractor.ts
+++ b/src/utils/metadata-extractor.ts
@@ -28,39 +28,17 @@ export class MetadataExtractor {
     const method = this.convertMethodValueToString(methodValue)
     if (!method) return null
 
-    const request = this.extractRequestMetadata(prototype, methodName)
-
     return {
       path,
       method,
       name: methodName,
-      description: metadata.description,
-      deprecated: metadata.deprecated,
-      tags: metadata.tags,
-      request,
-      response: metadata.response
+      ...metadata
     }
   }
 
   private static extractRequestMetadata(prototype: any, methodName: string) {
-    const request: Record<string, any> = {}
-
-    const bodyMetadata = Reflect.getMetadata(METADATA_KEYS.BODY, prototype, methodName)
-    if (bodyMetadata) {
-      request.body = bodyMetadata
-    }
-
-    const queryMetadata = Reflect.getMetadata(METADATA_KEYS.QUERY, prototype, methodName)
-    if (queryMetadata) {
-      request.query = queryMetadata
-    }
-
-    const paramMetadata = Reflect.getMetadata(METADATA_KEYS.PARAM, prototype, methodName)
-    if (paramMetadata) {
-      request.params = paramMetadata
-    }
-
-    return request
+    const endpointMetadata = Reflect.getMetadata(METADATA_KEYS.ENDPOINT, prototype, methodName)
+    return endpointMetadata?.request || {}
   }
 
   static extractMethodNames(prototype: any): string[] {

--- a/src/utils/metadata-extractor.ts
+++ b/src/utils/metadata-extractor.ts
@@ -36,11 +36,6 @@ export class MetadataExtractor {
     }
   }
 
-  private static extractRequestMetadata(prototype: any, methodName: string) {
-    const endpointMetadata = Reflect.getMetadata(METADATA_KEYS.ENDPOINT, prototype, methodName)
-    return endpointMetadata?.request || {}
-  }
-
   static extractMethodNames(prototype: any): string[] {
     return Object.getOwnPropertyNames(prototype).filter((prop) => prop !== 'constructor' && typeof prototype[prop] === 'function')
   }


### PR DESCRIPTION
This pull request includes significant refactoring and improvements to the `ApiDocsGenerator` class in the `src/generators/api-docs.generator.ts` file. The changes focus on improving the structure and readability of the code, as well as enhancing the functionality of the `generateDocs` method.

Refactoring and code improvements:

* [`src/generators/api-docs.generator.ts`](diffhunk://#diff-ac99ae691595cb9c45796b9cc63c6451cf00887d8aa328bca30f27e94716f08bL1-L5): Refactored the `generateDocs` method to take a `DiscoveryService` parameter instead of an `INestApplication` and a `Test` parameter. Added new private methods `validateDiscoveryService`, `storeControllersInfo`, `extractControllerInfo`, `isValidWrapper`, `extractEndpoints`, `getControllersInfo`, and `saveDocumentation` to improve code readability and maintainability. [[1]](diffhunk://#diff-ac99ae691595cb9c45796b9cc63c6451cf00887d8aa328bca30f27e94716f08bL1-L5) [[2]](diffhunk://#diff-ac99ae691595cb9c45796b9cc63c6451cf00887d8aa328bca30f27e94716f08bL25-R97)

Enhancements to functionality:

* [`src/generators/api-docs.generator.ts`](diffhunk://#diff-ac99ae691595cb9c45796b9cc63c6451cf00887d8aa328bca30f27e94716f08bL25-R97): Modified the `saveDocumentation` method to use `Promise.all` for saving project metadata and route documentation concurrently.
* [`src/utils/metadata-extractor.ts`](diffhunk://#diff-fe9762174fea24cabe4b7ec2e206a6a1f322d2eb2ce6fec95cd710f7b228e29cL31-L63): Simplified the `extractEndpointMetadata` method by removing the `extractRequestMetadata` method and using spread syntax to include metadata properties directly.