### PR TITLE
Refactor MetadataExtractor class to remove unnecessary null checks, unused code and update directory access

### DIFF
--- a/src/utils/file-manager.ts
+++ b/src/utils/file-manager.ts
@@ -14,9 +14,8 @@ export class FileManager {
   }
 
   async existsDirectory(dirPath: string): Promise<boolean> {
-    const fullPath = path.join(this.basePath, dirPath)
     try {
-      await fs.access(fullPath)
+      await fs.access(dirPath)
       return true
     } catch {
       return false
@@ -38,17 +37,6 @@ export class FileManager {
       await fs.writeFile(fullPath, JSON.stringify(data, null, DEFAULT_CONFIG.JSON_INDENT))
     } catch (error) {
       throw new Error(`${ERROR_MESSAGES.FILE_WRITE_FAILED}: ${error.message}`)
-    }
-  }
-
-  async createDirectoryStructure(): Promise<void> {
-    const directories = ['', DEFAULT_CONFIG.ROUTES]
-
-    for (const dir of directories) {
-      const isExist = await this.existsDirectory(dir)
-      if (!isExist) {
-        await this.createDirectory(dir)
-      }
     }
   }
 

--- a/src/utils/metadata-extractor.ts
+++ b/src/utils/metadata-extractor.ts
@@ -12,21 +12,15 @@ export class MetadataExtractor {
     }
   }
 
-  static extractControllerPath(controller: any): string | null {
+  static extractControllerPath(controller: any): string {
     return Reflect.getMetadata(METADATA_KEYS.PATH, controller)
   }
 
   static extractEndpointMetadata(prototype: any, methodName: string): ApiEndpoint | null {
     const metadata: ApiEndpointMetadata = Reflect.getMetadata(METADATA_KEYS.ENDPOINT, prototype, methodName)
-    if (!metadata) return null
-
     const path = Reflect.getMetadata(METADATA_KEYS.PATH, prototype[methodName])
     const methodValue = Reflect.getMetadata(METADATA_KEYS.METHOD, prototype[methodName])
-
-    if (!path || methodValue === undefined) return null
-
     const method = this.convertMethodValueToString(methodValue)
-    if (!method) return null
 
     return {
       path,
@@ -40,7 +34,7 @@ export class MetadataExtractor {
     return Object.getOwnPropertyNames(prototype).filter((prop) => prop !== 'constructor' && typeof prototype[prop] === 'function')
   }
 
-  private static convertMethodValueToString(methodValue: number): HttpMethod | null {
+  private static convertMethodValueToString(methodValue: number): HttpMethod {
     const methodMap: Record<number, HttpMethod> = {
       0: 'GET',
       1: 'POST',
@@ -52,6 +46,6 @@ export class MetadataExtractor {
       7: 'HEAD'
     }
 
-    return methodMap[methodValue] || null
+    return methodMap[methodValue]
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `FileManager` and `MetadataExtractor` classes in the `src/utils` directory. The modifications focus on simplifying methods and improving type consistency.

### Changes to `FileManager` class (`src/utils/file-manager.ts`):

* Simplified the `existsDirectory` method by removing the `fullPath` variable and directly using `dirPath`.
* Removed the `createDirectoryStructure` method, which included redundant directory creation logic.

### Changes to `MetadataExtractor` class (`src/utils/metadata-extractor.ts`):

* Updated the `extractControllerPath` method to always return a string, removing the possibility of returning `null`.
* Simplified the `extractEndpointMetadata` method by removing unnecessary null checks.
* Modified the `convertMethodValueToString` method to always return an `HttpMethod` type, eliminating the possibility of returning `null`. [[1]](diffhunk://#diff-fe9762174fea24cabe4b7ec2e206a6a1f322d2eb2ce6fec95cd710f7b228e29cL43-R37) [[2]](diffhunk://#diff-fe9762174fea24cabe4b7ec2e206a6a1f322d2eb2ce6fec95cd710f7b228e29cL55-R49)