### PR TITLE
Refactoring api-docs.generators.ts for srp

### DIFF
--- a/src/generators/api-docs.generator.ts
+++ b/src/generators/api-docs.generator.ts
@@ -1,10 +1,8 @@
-import type { ApiController } from '../interfaces'
-import { DiscoveryService } from '@nestjs/core'
-import { MetadataExtractor } from '../utils/metadata-extractor'
-import { FileManager } from '../utils/file-manager'
-import { ERROR_MESSAGES } from '../constants'
+import type { DiscoveryService } from '@nestjs/core'
+import { FileManager } from '../utils'
+import { ControllerExtractor, DocsWriter } from '.'
 
-interface ProjectMetadata {
+export interface ProjectMetadata {
   name: string
   description: string
   version: string
@@ -12,88 +10,22 @@ interface ProjectMetadata {
 }
 
 export class ApiDocsGenerator {
-  private readonly docs: ApiController[]
-  private readonly projectMetadata: ProjectMetadata
-  private readonly fileManager: FileManager
+  private readonly metadata: ProjectMetadata
+  private readonly writer: DocsWriter
+  private readonly controllerExtractor: ControllerExtractor
 
-  constructor(metadata: Omit<ProjectMetadata, 'routes'>, outputPath: string, targetFolder?: string) {
-    this.docs = []
-    this.projectMetadata = { ...metadata, routes: [] }
-    this.fileManager = new FileManager(outputPath, targetFolder)
+  constructor(metadata: Omit<ProjectMetadata, 'routes'>, outputPath: string, discoveryService: DiscoveryService, targetFolder?: string) {
+    this.metadata = { ...metadata, routes: [] }
+    this.writer = new DocsWriter(new FileManager(outputPath, targetFolder))
+    this.controllerExtractor = new ControllerExtractor(discoveryService)
   }
 
-  async generateDocs(discoveryService: DiscoveryService): Promise<void> {
-    this.validateDiscoveryService(discoveryService)
-    const data = await this.getControllersInfo(discoveryService)
-    this.storeControllersInfo(data)
-    await this.saveDocumentation()
-  }
-
-  private validateDiscoveryService(discoveryService: DiscoveryService): void {
-    if (!discoveryService) {
-      throw new Error(ERROR_MESSAGES.NO_DISCOVERY_SERVICE)
+  async generate(): Promise<void> {
+    const controllers = await this.controllerExtractor.extract()
+    const projectMetadata: ProjectMetadata = {
+      ...this.metadata,
+      routes: controllers.map((controller) => controller.basePath)
     }
-  }
-
-  private storeControllersInfo(data: ApiController[]) {
-    for (const info of data) {
-      this.projectMetadata.routes.push(info.basePath)
-      this.docs.push(info)
-    }
-  }
-
-  private extractControllerInfo(wrapper: { instance: any; metatype: any }): ApiController | null {
-    if (!this.isValidWrapper(wrapper)) return null
-
-    const prototype = Object.getPrototypeOf(wrapper.instance)
-    const controllerPath = MetadataExtractor.extractControllerPath(wrapper.metatype)
-    if (!controllerPath) return null
-
-    const endpoints = this.extractEndpoints(prototype)
-    if (endpoints.length === 0) return null
-
-    const controllerMetadata = MetadataExtractor.extractControllerMetadata(wrapper.metatype)
-
-    return {
-      controllerName: wrapper.metatype.name,
-      basePath: controllerPath,
-      description: controllerMetadata?.description,
-      tags: controllerMetadata?.tags,
-      endpoints
-    }
-  }
-
-  private isValidWrapper(wrapper: { instance: any; metatype: any }): boolean {
-    return !!(wrapper.instance && wrapper.metatype)
-  }
-
-  private extractEndpoints(prototype: any): ApiController['endpoints'] {
-    const methodNames = MetadataExtractor.extractMethodNames(prototype)
-    return methodNames
-      .map((methodName) => MetadataExtractor.extractEndpointMetadata(prototype, methodName))
-      .filter((endpoint): endpoint is NonNullable<typeof endpoint> => endpoint !== null)
-  }
-
-  private async getControllersInfo(discoveryService: DiscoveryService) {
-    const controllers = discoveryService.getControllers()
-    const extractions: ApiController[] = []
-    for (const wrapper of controllers) {
-      const controllerInfo = this.extractControllerInfo(wrapper)
-      if (controllerInfo) extractions.push(controllerInfo)
-    }
-    return extractions
-  }
-
-  private async saveDocumentation(): Promise<void> {
-    await this.fileManager.createDirectoryStructure()
-    await Promise.all([this.saveProjectMetadata(), this.saveRouteDocs()])
-  }
-
-  private async saveProjectMetadata(): Promise<void> {
-    await this.fileManager.saveJson('projects', this.projectMetadata)
-  }
-
-  private async saveRouteDocs(): Promise<void> {
-    await Promise.all(this.docs.map((doc) => this.fileManager.saveJson(`routes/${doc.basePath}`, doc)))
+    await this.writer.writeDocumentation({ projectMetadata, controllers })
   }
 }

--- a/src/generators/controller-extractor.ts
+++ b/src/generators/controller-extractor.ts
@@ -1,0 +1,48 @@
+import type { ApiController } from '../interfaces'
+import { DiscoveryService } from '@nestjs/core'
+import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper'
+import { MetadataExtractor } from '../utils/metadata-extractor'
+import { ERROR_MESSAGES } from '../constants'
+
+export class ControllerExtractor {
+  constructor(private readonly discoveryService: DiscoveryService) {
+    this.validateDiscoveryService()
+  }
+
+  private validateDiscoveryService(): void {
+    if (!this.discoveryService) {
+      throw new Error(ERROR_MESSAGES.NO_DISCOVERY_SERVICE)
+    }
+  }
+
+  async extract(): Promise<ApiController[]> {
+    const controllers = this.discoveryService.getControllers()
+    return controllers.map((wrapper) => this.extractControllerInfo(wrapper)).filter((info): info is ApiController => info !== null)
+  }
+
+  private extractControllerInfo(wrapper: InstanceWrapper<any>): ApiController | null {
+    if (!this.isValidWrapper(wrapper)) return null
+
+    const prototype = Object.getPrototypeOf(wrapper.instance)
+    const controllerPath = MetadataExtractor.extractControllerPath(wrapper.metatype)
+    if (!controllerPath) return null
+
+    const methodNames = MetadataExtractor.extractMethodNames(prototype)
+    const endpoints = methodNames
+      .map((methodName) => MetadataExtractor.extractEndpointMetadata(prototype, methodName))
+      .filter((endpoint): endpoint is NonNullable<typeof endpoint> => endpoint !== null)
+    const controllerMetadata = MetadataExtractor.extractControllerMetadata(wrapper.metatype)
+
+    return {
+      controllerName: wrapper.metatype.name,
+      basePath: controllerPath,
+      description: controllerMetadata?.description,
+      tags: controllerMetadata?.tags,
+      endpoints
+    }
+  }
+
+  private isValidWrapper(wrapper: { instance: any; metatype: any }): boolean {
+    return !!(wrapper.instance && wrapper.metatype)
+  }
+}

--- a/src/generators/docs-writer.ts
+++ b/src/generators/docs-writer.ts
@@ -1,0 +1,29 @@
+import type { ApiController } from '../interfaces'
+import { FileManager } from '../utils'
+
+interface WriteData {
+  projectMetadata: unknown
+  controllers: ApiController[]
+}
+
+export class DocsWriter {
+  private readonly requiredDirectories = ['', 'routes']
+
+  constructor(private readonly fileManager: FileManager) {}
+
+  async writeDocumentation({ projectMetadata, controllers }: WriteData): Promise<void> {
+    for (const dir of this.requiredDirectories) {
+      const isExist = await this.fileManager.existsDirectory(dir)
+      if (!isExist) this.fileManager.createDirectory(dir)
+    }
+    await Promise.all([this.writeProjectMetadata(projectMetadata), this.writeControllerDocs(controllers)])
+  }
+
+  private async writeProjectMetadata(metadata: unknown): Promise<void> {
+    await this.fileManager.saveJson('projects', metadata)
+  }
+
+  private async writeControllerDocs(controllers: ApiController[]): Promise<void> {
+    await Promise.all(controllers.map((doc) => this.fileManager.saveJson(`routes/${doc.basePath}`, doc)))
+  }
+}

--- a/src/generators/index.ts
+++ b/src/generators/index.ts
@@ -1,1 +1,3 @@
 export * from './api-docs.generator'
+export * from './controller-extractor'
+export * from './docs-writer'


### PR DESCRIPTION
This pull request refactors the API documentation generation process by modularizing the code into separate classes for better maintainability and readability. The key changes include the introduction of new classes for extracting controller metadata and writing documentation, as well as updates to the main generator class to utilize these new components.

Refactoring and modularization:

* [`src/generators/api-docs.generator.ts`](diffhunk://#diff-ac99ae691595cb9c45796b9cc63c6451cf00887d8aa328bca30f27e94716f08bL1-R29): Refactored the `ApiDocsGenerator` class to use new `ControllerExtractor` and `DocsWriter` classes, simplifying the constructor and `generate` method. Removed redundant methods that are now handled by the new classes.
* [`src/generators/controller-extractor.ts`](diffhunk://#diff-ecd2095ada3fabb327b7554b8d19f3c9fa46e6f355a3714a51cae5bf8b0b9f42R1-R48): Introduced the `ControllerExtractor` class to encapsulate logic for extracting controller metadata from the `DiscoveryService`.
* [`src/generators/docs-writer.ts`](diffhunk://#diff-1d6c8b2e2ae673b38022a94ababb93a8e9a0d9546f2fb3b6e27ff3ca74265160R1-R29): Introduced the `DocsWriter` class to handle writing project metadata and controller documentation to files.
* [`src/generators/index.ts`](diffhunk://#diff-480d36a296821a122d6072387c7596eef4c123210e134f6d78d30d13472b2f82R2-R3): Exported the new `ControllerExtractor` and `DocsWriter` classes to make them available for use in other modules.