### PR TITLE
Remove redundant type declarations in decorator.interface.ts

### DIFF
--- a/src/generators/docs-writer.ts
+++ b/src/generators/docs-writer.ts
@@ -14,7 +14,7 @@ export class DocsWriter {
   async writeDocumentation({ projectMetadata, controllers }: WriteData): Promise<void> {
     for (const dir of this.requiredDirectories) {
       const isExist = await this.fileManager.existsDirectory(dir)
-      if (!isExist) this.fileManager.createDirectory(dir)
+      if (!isExist) await this.fileManager.createDirectory(dir)
     }
     await Promise.all([this.writeProjectMetadata(projectMetadata), this.writeControllerDocs(controllers)])
   }

--- a/src/interfaces/decorator.interface.ts
+++ b/src/interfaces/decorator.interface.ts
@@ -10,23 +10,19 @@ export interface EndpointDecoratorMetadata<P extends DefaultMetadataProperties> 
   description: string
   request?: {
     body?: {
-      type: string
       properties: P['body'] extends string ? Record<P['body'], ApiProperty> : never
       required?: string[]
     }
     query?: {
-      type: string
       properties: P['query'] extends string ? Record<P['query'], ApiProperty> : never
       required?: string[]
     }
     params?: {
-      type: string
       properties: P['params'] extends string ? Record<P['params'], ApiProperty> : never
       required?: string[]
     }
   }
   response?: {
-    type: string
     properties?: P['response'] extends string ? Record<P['response'], ApiProperty> : never
     example?: P['response'] extends string ? Record<P['response'], any> | Array<Record<P['response'], any>> : never
   }


### PR DESCRIPTION
This pull request includes changes to improve the `DocsWriter` class's handling of asynchronous operations and to simplify the `EndpointDecoratorMetadata` interface by removing redundant properties.

Improvements to asynchronous operations:

* [`src/generators/docs-writer.ts`](diffhunk://#diff-1d6c8b2e2ae673b38022a94ababb93a8e9a0d9546f2fb3b6e27ff3ca74265160L17-R17): Modified the `writeDocumentation` method to use `await` when calling `createDirectory` to ensure that the directory creation is completed before proceeding.

Simplification of interfaces:

* [`src/interfaces/decorator.interface.ts`](diffhunk://#diff-fdca2ab58e5c74cf32110041671f52f858e7eb35f20cd2d06761b8f6a41dbeb8L13-L29): Removed unnecessary `type` properties from the `body`, `query`, `params`, and `response` objects in the `EndpointDecoratorMetadata` interface to streamline the interface definition.