### PR TITLE
Add MetadataExtractor tests for controller metadata extraction

### DIFF
--- a/src/__test__/__fixtures__/controllers/todo.controller.ts
+++ b/src/__test__/__fixtures__/controllers/todo.controller.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { DocsTodoController, DocsGetAllTodos, DocsCreateTodo, DocsUpdateTodo, DocsDeleteTodo } from '../mocks'
+import { Controller } from '@nestjs/common'
+import { DocsTodoController, DocsGetAllTodos, DocsCreateTodo, DocsUpdateTodo, DocsDeleteTodo } from '../decorators'
 import { CreateTodoDto, TodoItem, UpdateTodoDto } from '../types'
 
+@Controller('todo')
 @DocsTodoController()
 export class TodoController {
   @DocsGetAllTodos()

--- a/src/__test__/utils/metadata-extractor.spec.ts
+++ b/src/__test__/utils/metadata-extractor.spec.ts
@@ -1,0 +1,39 @@
+// src/__tests__/decorators/controller.test.ts
+
+import { MetadataExtractor } from '../../utils'
+import { TodoController } from '../__fixtures__/controllers/todo.controller'
+import { getMockData } from '../__fixtures__/mocks'
+
+describe('Testing MetadataExtractor is extract expected data', () => {
+  it('should store controller metadata correctly', () => {
+    const metadata = MetadataExtractor.extractControllerMetadata(TodoController)
+    expect(metadata).toBeDefined()
+    expect(metadata).toEqual({
+      description: 'Todo items management',
+      tags: ['todos']
+    })
+  })
+
+  it('should return controller path metadata', () => {
+    const path = MetadataExtractor.extractControllerPath(TodoController)
+    expect(path).toBeDefined()
+    expect(path).toEqual('todo')
+  })
+
+  it('should return method names of controller', () => {
+    const prototype = TodoController.prototype
+    const methodNames = MetadataExtractor.extractMethodNames(prototype)
+    expect(methodNames).toBeDefined()
+    expect(methodNames.length).toBeGreaterThan(0)
+  })
+
+  it('should return endpoint metadata', () => {
+    const prototype = TodoController.prototype
+    const methodNames = MetadataExtractor.extractMethodNames(prototype) as any[]
+    const metadata = MetadataExtractor.extractEndpointMetadata(prototype, methodNames[0])
+    const mock = getMockData('todo', methodNames[0])
+
+    expect(metadata).toBeDefined()
+    expect(metadata?.description).toEqual(mock.description)
+  })
+})


### PR DESCRIPTION
This pull request includes changes to the `TodoController` and introduces new tests for the `MetadataExtractor` utility. The most important changes include modifying the import statements and decorators in the `TodoController` and adding comprehensive unit tests for the `MetadataExtractor`.

Changes to `TodoController`:

* [`src/__test__/__fixtures__/controllers/todo.controller.ts`](diffhunk://#diff-a7f3ed5f3de9a1e58bea45f85d142a1871a5972b6c9ba77014bdf1072dd96a83L2-R6): Modified import statements to use `@nestjs/common` and `../decorators` instead of `../mocks`. Added the `@Controller('todo')` decorator to the `TodoController` class.

New tests for `MetadataExtractor`:

* [`src/__test__/utils/metadata-extractor.spec.ts`](diffhunk://#diff-1a5b336a70206b443d8713a81ec92487f1b6c48dcd0ff7d14452b87d0a50f5c3R1-R39): Added unit tests to verify that `MetadataExtractor` correctly extracts controller metadata, path metadata, method names, and endpoint metadata from the `TodoController`.