### PR TITLE
Add unit tests for FileManager class

### DIFF
--- a/src/__test__/utils/file-manager.spec.ts
+++ b/src/__test__/utils/file-manager.spec.ts
@@ -1,0 +1,25 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { FileManager } from '../../utils'
+
+describe('Testing FileManger is behaving as predicted', () => {
+  const testPath = path.join(process.cwd(), '/src/__test__/utils')
+  const fileManager = new FileManager(testPath)
+
+  it('should create api-docs folder at testPath when used createDirectory', async () => {
+    await fileManager.createDirectory()
+    expect(fs.existsSync(testPath + '/api-docs')).toBeTruthy()
+    await fileManager.cleanDirectory()
+    expect(fs.existsSync(testPath + '/api-docs')).toBeFalsy()
+  })
+
+  it('should convert user-supplied data to a JSON file', async () => {
+    const test = { message: 'hello world!' }
+    await fileManager.createDirectory()
+    expect(fs.existsSync(testPath + '/api-docs')).toBeTruthy()
+    await fileManager.saveJson('testing', test)
+    expect(fs.existsSync(testPath + '/api-docs/testing.json')).toBeTruthy()
+    await fileManager.cleanDirectory()
+    expect(fs.existsSync(testPath + '/api-docs')).toBeFalsy()
+  })
+})

--- a/src/utils/file-manager.ts
+++ b/src/utils/file-manager.ts
@@ -9,7 +9,7 @@ export class FileManager {
     if (!inputPath) {
       throw new Error(ERROR_MESSAGES.INVALID_PATH)
     }
-    this.basePath = path.isAbsolute(inputPath) ? inputPath : path.join(process.cwd(), inputPath)
+    this.basePath = path.isAbsolute(inputPath) ? inputPath + '/' : path.join(process.cwd(), inputPath, '/')
     this.basePath += targetFolder
   }
 
@@ -22,7 +22,7 @@ export class FileManager {
     }
   }
 
-  async createDirectory(dirPath: string): Promise<void> {
+  async createDirectory(dirPath: string = ''): Promise<void> {
     const fullPath = path.join(this.basePath, dirPath)
     try {
       await fs.mkdir(fullPath, { recursive: true })


### PR DESCRIPTION
This pull request includes changes to the `FileManager` class and adds new tests to ensure its functionality. The most important changes include modifying the `createDirectory` method to have a default parameter, adjusting the base path initialization, and adding tests for directory creation and JSON file saving.

Changes to `FileManager` class:

* [`src/utils/file-manager.ts`](diffhunk://#diff-b084a0eea23f7d25c97ec26a713c2972de13a552e837d3e1d10bb0aa060e7225L25-R25): Modified the `createDirectory` method to have a default parameter of an empty string. This change simplifies the method call when no specific directory path is provided.
* [`src/utils/file-manager.ts`](diffhunk://#diff-b084a0eea23f7d25c97ec26a713c2972de13a552e837d3e1d10bb0aa060e7225L12-R12): Adjusted the base path initialization to ensure it always ends with a slash, improving path consistency.

Additions to tests:

* [`src/__test__/utils/file-manager.spec.ts`](diffhunk://#diff-3039a7e80ac5f7b0942d5afbc4b47741b75bcf96b2d5c8a70737df447f3e5e6aR1-R25): Added tests to verify that the `FileManager` class correctly creates and cleans directories, and converts user-supplied data to a JSON file.