### PR TITLE
Add controller extractor unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "url": "https://github.com/vvsogi/doke/issues"
   },
   "homepage": "https://github.com/vvsogi/doke#readme",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "files": [
     "dist"
   ],

--- a/src/__test__/generators/controller-extractor.spec.ts
+++ b/src/__test__/generators/controller-extractor.spec.ts
@@ -1,10 +1,14 @@
 import { DiscoveryService } from '@nestjs/core'
 import { ControllerExtractor } from '../../generators'
 import { ERROR_MESSAGES } from '../../constants'
+import { TodoController } from '../__fixtures__/controllers'
+import { getControllersMockData } from '../__fixtures__/mocks'
 
-describe('ControllerExtractor', () => {
+describe('Testing ControllerExtractor extract right data', () => {
   let controllerExtractor: ControllerExtractor
   let mockDiscoveryService: jest.Mocked<DiscoveryService>
+  let controller: TodoController
+  let mockWrapper: any
 
   beforeEach(() => {
     mockDiscoveryService = {
@@ -12,6 +16,35 @@ describe('ControllerExtractor', () => {
     } as any
 
     controllerExtractor = new ControllerExtractor(mockDiscoveryService)
+    controller = new TodoController()
+    mockWrapper = {
+      instance: controller,
+      metatype: TodoController,
+      name: 'TodoController',
+      token: TodoController,
+      async: false,
+      host: undefined,
+      isAlias: false,
+      scope: undefined,
+      dependencies: [],
+      providers: [],
+      initTime: 0,
+      enhancerMetadata: undefined,
+      isDependencyTreeStatic: () => true,
+      getDependencyContext: () => ({}),
+      getInstanceByContextId: () => controller,
+      setInstanceByContextId: () => {},
+      getStaticTransientInstances: () => [],
+      cloneStaticInstance: () => controller,
+      createPrototype: () => controller,
+      isNotMetatype: () => false,
+      isTransient: () => false,
+      initialize: () => Promise.resolve(controller),
+      setIsRequestScoped: () => {},
+      setInstanceByInquirerId: () => {},
+      getInstanceByInquirerId: () => controller,
+      values: []
+    } as any
   })
 
   it('should throw error when DiscoveryService is not provided', () => {
@@ -19,13 +52,12 @@ describe('ControllerExtractor', () => {
   })
 
   it('should extract controller information correctly', async () => {
-    const mockWrapper = {
-      hello: 'world'
-    } as any
-
     mockDiscoveryService.getControllers.mockReturnValue([mockWrapper])
     const result = await controllerExtractor.extract()
 
     expect(result).toHaveLength(1)
+    expect(result[0].controllerName).toEqual(TodoController.name)
+    expect(result[0].description).toEqual(getControllersMockData('todoController').description)
+    expect(result[0].basePath).toEqual('todo')
   })
 })

--- a/src/__test__/generators/controller-extractor.spec.ts
+++ b/src/__test__/generators/controller-extractor.spec.ts
@@ -1,0 +1,31 @@
+import { DiscoveryService } from '@nestjs/core'
+import { ControllerExtractor } from '../../generators'
+import { ERROR_MESSAGES } from '../../constants'
+
+describe('ControllerExtractor', () => {
+  let controllerExtractor: ControllerExtractor
+  let mockDiscoveryService: jest.Mocked<DiscoveryService>
+
+  beforeEach(() => {
+    mockDiscoveryService = {
+      getControllers: jest.fn()
+    } as any
+
+    controllerExtractor = new ControllerExtractor(mockDiscoveryService)
+  })
+
+  it('should throw error when DiscoveryService is not provided', () => {
+    expect(() => new ControllerExtractor(undefined as any)).toThrow(ERROR_MESSAGES.NO_DISCOVERY_SERVICE)
+  })
+
+  it('should extract controller information correctly', async () => {
+    const mockWrapper = {
+      hello: 'world'
+    } as any
+
+    mockDiscoveryService.getControllers.mockReturnValue([mockWrapper])
+    const result = await controllerExtractor.extract()
+
+    expect(result).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
This pull request includes changes to the `package.json` file and adds a new test suite for the `ControllerExtractor` class. The most important changes are summarized below:

### Changes to `package.json`:

* Updated the `main` and `types` fields to point to `dist/src/index.js` and `dist/src/index.d.ts` respectively.

### Additions to `ControllerExtractor` tests:

* Added a new test suite in `src/__test__/generators/controller-extractor.spec.ts` to test the `ControllerExtractor` class, including setup for `DiscoveryService` and mock data for controllers.
* Added tests to ensure the `ControllerExtractor` throws an error when `DiscoveryService` is not provided and correctly extracts controller information.