### PR TITLE
Add unit testing that ApiDocsGenerator creates json

### DIFF
--- a/src/__test__/generators/api-docs.generator.spec.ts
+++ b/src/__test__/generators/api-docs.generator.spec.ts
@@ -1,0 +1,64 @@
+import { DiscoveryService } from '@nestjs/core'
+import { ApiDocsGenerator } from '../../generators'
+import { ControllerExtractor, DocsWriter } from '../../generators'
+
+jest.mock('../../utils/file-manager')
+jest.mock('../../generators/controller-extractor')
+jest.mock('../../generators/docs-writer')
+
+describe('ApiDocsGenerator', () => {
+  let apiDocsGenerator: ApiDocsGenerator
+  let mockDiscoveryService: jest.Mocked<DiscoveryService>
+  let mockControllerExtractor: jest.Mocked<ControllerExtractor>
+  let mockDocsWriter: jest.Mocked<DocsWriter>
+
+  const testMetadata = {
+    name: 'test-api',
+    description: 'Test API Description',
+    version: '1.0.0'
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockDiscoveryService = {
+      getControllers: jest.fn()
+    } as any
+
+    mockDiscoveryService = {
+      getControllers: jest.fn()
+    } as any
+
+    mockControllerExtractor = {
+      extract: jest.fn()
+    } as any
+
+    mockDocsWriter = {
+      writeDocumentation: jest.fn()
+    } as any
+
+    const mockControllers = [
+      {
+        controllerName: 'TodoController',
+        basePath: 'todo',
+        description: 'Todo items management',
+        tags: ['todos'],
+        endpoints: []
+      }
+    ]
+
+    mockControllerExtractor.extract.mockResolvedValue(mockControllers)
+    mockDocsWriter.writeDocumentation.mockResolvedValue(undefined)
+
+    jest.spyOn(ControllerExtractor.prototype, 'extract').mockImplementation(mockControllerExtractor.extract)
+    jest.spyOn(DocsWriter.prototype, 'writeDocumentation').mockImplementation(mockDocsWriter.writeDocumentation)
+
+    apiDocsGenerator = new ApiDocsGenerator(testMetadata, 'test-output-path', mockDiscoveryService)
+  })
+
+  it('should generate documentation successfully', async () => {
+    await apiDocsGenerator.generate()
+
+    expect(mockControllerExtractor.extract).toHaveBeenCalled()
+  })
+})

--- a/src/__test__/generators/api-docs.generator.spec.ts
+++ b/src/__test__/generators/api-docs.generator.spec.ts
@@ -6,7 +6,7 @@ jest.mock('../../utils/file-manager')
 jest.mock('../../generators/controller-extractor')
 jest.mock('../../generators/docs-writer')
 
-describe('ApiDocsGenerator', () => {
+describe('Testing that ApiDocsGenerator creates json files with the correct data', () => {
   let apiDocsGenerator: ApiDocsGenerator
   let mockDiscoveryService: jest.Mocked<DiscoveryService>
   let mockControllerExtractor: jest.Mocked<ControllerExtractor>
@@ -20,10 +20,6 @@ describe('ApiDocsGenerator', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-
-    mockDiscoveryService = {
-      getControllers: jest.fn()
-    } as any
 
     mockDiscoveryService = {
       getControllers: jest.fn()
@@ -60,5 +56,30 @@ describe('ApiDocsGenerator', () => {
     await apiDocsGenerator.generate()
 
     expect(mockControllerExtractor.extract).toHaveBeenCalled()
+    expect(mockDocsWriter.writeDocumentation).toHaveBeenCalledWith({
+      projectMetadata: {
+        ...testMetadata,
+        routes: ['todo']
+      },
+      controllers: expect.arrayContaining([
+        expect.objectContaining({
+          controllerName: 'TodoController',
+          basePath: 'todo'
+        })
+      ])
+    })
+  })
+
+  it('should handle empty controller list', async () => {
+    mockControllerExtractor.extract.mockResolvedValue([])
+    await apiDocsGenerator.generate()
+
+    expect(mockDocsWriter.writeDocumentation).toHaveBeenCalledWith({
+      projectMetadata: {
+        ...testMetadata,
+        routes: []
+      },
+      controllers: []
+    })
   })
 })


### PR DESCRIPTION
This pull request introduces a new test suite for the `ApiDocsGenerator` class in the `src/__test__/generators/api-docs.generator.spec.ts` file. The tests ensure that the `ApiDocsGenerator` correctly generates JSON files with the appropriate data and handles edge cases such as an empty controller list.

Key changes include:

* **Introduction of mocks and test setup:**
  * Added mocks for `DiscoveryService`, `ControllerExtractor`, and `DocsWriter` to simulate their behavior during testing. (`src/__test__/generators/api-docs.generator.spec.ts`)
  * Configured the test metadata and mock implementations for `extract` and `writeDocumentation` methods. (`src/__test__/generators/api-docs.generator.spec.ts`)

* **Test cases:**
  * Added a test case to verify that the `ApiDocsGenerator` generates documentation successfully, including the correct project metadata and controller details. (`src/__test__/generators/api-docs.generator.spec.ts`)
  * Added a test case to ensure that the `ApiDocsGenerator` handles an empty controller list gracefully, generating documentation with empty routes and controllers. (`src/__test__/generators/api-docs.generator.spec.ts`)