### PR TITLE
Add unit test for Todo API decorator

### DIFF
--- a/src/__test__/decorators/todo-api.decorator.spec.ts
+++ b/src/__test__/decorators/todo-api.decorator.spec.ts
@@ -1,0 +1,18 @@
+import { MetadataExtractor } from '../../utils'
+import { TodoController } from '../__fixtures__/controllers'
+import { getAllTodos } from '../__fixtures__/mocks/todo'
+
+describe('Todo API Decorators', () => {
+  describe('DocsGetAllTodos', () => {
+    it('should call ApiDocsEndpoint with correct metadata from mock', () => {
+      const mock = getAllTodos
+      const prototype = TodoController.prototype
+      const methodNames = MetadataExtractor.extractMethodNames(prototype) as any[]
+      const getAllTodosMethod = methodNames.find((method) => method === 'getAllTodos')
+      const metadata = MetadataExtractor.extractEndpointMetadata(prototype, getAllTodosMethod)
+
+      expect(metadata?.description).toEqual(mock.description)
+      expect(metadata?.response).toEqual(mock.response)
+    })
+  })
+})

--- a/src/__test__/decorators/todo-api.decorator.spec.ts
+++ b/src/__test__/decorators/todo-api.decorator.spec.ts
@@ -1,10 +1,10 @@
 import { MetadataExtractor } from '../../utils'
 import { TodoController } from '../__fixtures__/controllers'
-import { getAllTodos } from '../__fixtures__/mocks/todo'
+import { createTodo, getAllTodos } from '../__fixtures__/mocks/todo'
 
 describe('Todo API Decorators', () => {
   describe('DocsGetAllTodos', () => {
-    it('should call ApiDocsEndpoint with correct metadata from mock', () => {
+    it('should call with correct metadata from mock', () => {
       const mock = getAllTodos
       const prototype = TodoController.prototype
       const methodNames = MetadataExtractor.extractMethodNames(prototype) as any[]
@@ -12,6 +12,20 @@ describe('Todo API Decorators', () => {
       const metadata = MetadataExtractor.extractEndpointMetadata(prototype, getAllTodosMethod)
 
       expect(metadata?.description).toEqual(mock.description)
+      expect(metadata?.response).toEqual(mock.response)
+    })
+  })
+
+  describe('DocsCreateTodo', () => {
+    it('should call with correct metadata from mock', () => {
+      const mock = createTodo
+      const prototype = TodoController.prototype
+      const methodNames = MetadataExtractor.extractMethodNames(prototype) as any[]
+      const createTodoMethod = methodNames.find((method) => method === 'createTodo')
+      const metadata = MetadataExtractor.extractEndpointMetadata(prototype, createTodoMethod)
+
+      expect(metadata?.description).toEqual(mock.description)
+      expect(metadata?.request).toEqual(mock.request)
       expect(metadata?.response).toEqual(mock.response)
     })
   })

--- a/src/__test__/decorators/todo-api.decorator.spec.ts
+++ b/src/__test__/decorators/todo-api.decorator.spec.ts
@@ -1,6 +1,6 @@
 import { MetadataExtractor } from '../../utils'
 import { TodoController } from '../__fixtures__/controllers'
-import { createTodo, getAllTodos } from '../__fixtures__/mocks/todo'
+import { createTodo, getAllTodos, updateTodo } from '../__fixtures__/mocks/todo'
 
 describe('Todo API Decorators', () => {
   describe('DocsGetAllTodos', () => {
@@ -23,6 +23,20 @@ describe('Todo API Decorators', () => {
       const methodNames = MetadataExtractor.extractMethodNames(prototype) as any[]
       const createTodoMethod = methodNames.find((method) => method === 'createTodo')
       const metadata = MetadataExtractor.extractEndpointMetadata(prototype, createTodoMethod)
+
+      expect(metadata?.description).toEqual(mock.description)
+      expect(metadata?.request).toEqual(mock.request)
+      expect(metadata?.response).toEqual(mock.response)
+    })
+  })
+
+  describe('DocsUpdateTodo', () => {
+    it('should call with correct metadata from mock', () => {
+      const mock = updateTodo
+      const prototype = TodoController.prototype
+      const methodNames = MetadataExtractor.extractMethodNames(prototype) as any[]
+      const updateTodoMethod = methodNames.find((method) => method === 'updateTodo')
+      const metadata = MetadataExtractor.extractEndpointMetadata(prototype, updateTodoMethod)
 
       expect(metadata?.description).toEqual(mock.description)
       expect(metadata?.request).toEqual(mock.request)

--- a/src/__test__/decorators/todo-api.decorator.spec.ts
+++ b/src/__test__/decorators/todo-api.decorator.spec.ts
@@ -1,6 +1,6 @@
 import { MetadataExtractor } from '../../utils'
 import { TodoController } from '../__fixtures__/controllers'
-import { createTodo, getAllTodos, updateTodo } from '../__fixtures__/mocks/todo'
+import { createTodo, deleteTodo, getAllTodos, updateTodo } from '../__fixtures__/mocks/todo'
 
 describe('Todo API Decorators', () => {
   describe('DocsGetAllTodos', () => {
@@ -37,6 +37,20 @@ describe('Todo API Decorators', () => {
       const methodNames = MetadataExtractor.extractMethodNames(prototype) as any[]
       const updateTodoMethod = methodNames.find((method) => method === 'updateTodo')
       const metadata = MetadataExtractor.extractEndpointMetadata(prototype, updateTodoMethod)
+
+      expect(metadata?.description).toEqual(mock.description)
+      expect(metadata?.request).toEqual(mock.request)
+      expect(metadata?.response).toEqual(mock.response)
+    })
+  })
+
+  describe('DocsDeleteTodo', () => {
+    it('should call with correct metadata from mock', () => {
+      const mock = deleteTodo
+      const prototype = TodoController.prototype
+      const methodNames = MetadataExtractor.extractMethodNames(prototype) as any[]
+      const deleteTodoMethod = methodNames.find((method) => method === 'deleteTodo')
+      const metadata = MetadataExtractor.extractEndpointMetadata(prototype, deleteTodoMethod)
 
       expect(metadata?.description).toEqual(mock.description)
       expect(metadata?.request).toEqual(mock.request)


### PR DESCRIPTION
This pull request adds new tests for the `TodoController` in the `src/__test__/decorators/todo-api.decorator.spec.ts` file. These tests ensure that the metadata extracted from the controller methods matches the expected mock data.

The most important changes include:

* Added tests for `DocsGetAllTodos` to verify that the metadata extracted from the `getAllTodos` method matches the mock data.
* Added tests for `DocsCreateTodo` to verify that the metadata extracted from the `createTodo` method matches the mock data.
* Added tests for `DocsUpdateTodo` to verify that the metadata extracted from the `updateTodo` method matches the mock data.
* Added tests for `DocsDeleteTodo` to verify that the metadata extracted from the `deleteTodo` method matches the mock data.