### PR TITLE
Refactor decorator interface and update required property

### DIFF
--- a/src/interfaces/decorator.interface.ts
+++ b/src/interfaces/decorator.interface.ts
@@ -16,15 +16,12 @@ export interface EndpointDecoratorMetadata<P extends DefaultMetadataProperties> 
   request?: {
     body?: {
       properties: P['body'] extends string ? Record<P['body'], ApiProperty> : never
-      required?: string[]
     }
     query?: {
       properties: P['query'] extends string ? Record<P['query'], ApiProperty> : never
-      required?: string[]
     }
     params?: {
       properties: P['params'] extends string ? Record<P['params'], ApiProperty> : never
-      required?: string[]
     }
   }
   response?: {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -3,7 +3,7 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'ALL' | '
 export interface ApiProperty {
   type: string
   description: string
-  required?: boolean
+  required: boolean
   example?: any
   enum?: string[]
   items?: ApiProperty


### PR DESCRIPTION
1. remove required in request parameters

Changes to API request and response definitions:

* [`src/interfaces/decorator.interface.ts`](diffhunk://#diff-fdca2ab58e5c74cf32110041671f52f858e7eb35f20cd2d06761b8f6a41dbeb8L19-L27): Removed the optional `required` property from the `body`, `query`, and `params` sections within the `request` object.

Changes to API property definitions:

* [`src/interfaces/index.ts`](diffhunk://#diff-2433a58dd5b382f3ef0faf44d5ab97bf79428a0a1452d72934c9ca3c77a237bcL6-R6): Changed the `required` property in the `ApiProperty` interface from optional to mandatory.