### PR TITLE
Remove in response properties property

### DIFF
--- a/src/__test__/__fixtures__/mocks/todo/createTodo.mock.ts
+++ b/src/__test__/__fixtures__/mocks/todo/createTodo.mock.ts
@@ -10,29 +10,5 @@ export const createTodo = {
         }
       }
     }
-  },
-  response: {
-    properties: {
-      id: {
-        type: 'string',
-        description: 'Created todo item ID'
-      },
-      title: {
-        type: 'string',
-        description: 'Todo item title'
-      },
-      completed: {
-        type: 'boolean',
-        description: 'Completion status'
-      },
-      createdAt: {
-        type: 'string',
-        description: 'Creation timestamp'
-      },
-      updatedAt: {
-        type: 'string',
-        description: 'Last update timestamp'
-      }
-    }
   }
 }

--- a/src/__test__/__fixtures__/mocks/todo/deleteTodo.mock.ts
+++ b/src/__test__/__fixtures__/mocks/todo/deleteTodo.mock.ts
@@ -11,12 +11,5 @@ export const deleteTodo = {
       }
     }
   },
-  response: {
-    properties: {
-      success: {
-        type: 'boolean',
-        description: 'Deletion success status'
-      }
-    }
-  }
+  response: {}
 }

--- a/src/__test__/__fixtures__/mocks/todo/getAllTodos.mock.ts
+++ b/src/__test__/__fixtures__/mocks/todo/getAllTodos.mock.ts
@@ -1,28 +1,6 @@
 export const getAllTodos = {
   description: 'Get all todo items',
   response: {
-    properties: {
-      id: {
-        type: 'string',
-        description: 'Todo item ID'
-      },
-      title: {
-        type: 'string',
-        description: 'Todo item title'
-      },
-      completed: {
-        type: 'boolean',
-        description: 'Completion status'
-      },
-      createdAt: {
-        type: 'string',
-        description: 'Creation timestamp'
-      },
-      updatedAt: {
-        type: 'string',
-        description: 'Last update timestamp'
-      }
-    },
     example: [
       {
         id: '123',

--- a/src/__test__/__fixtures__/mocks/todo/updateTodo.mock.ts
+++ b/src/__test__/__fixtures__/mocks/todo/updateTodo.mock.ts
@@ -25,28 +25,5 @@ export const updateTodo = {
       }
     }
   },
-  response: {
-    properties: {
-      id: {
-        type: 'string',
-        description: 'Updated todo item ID'
-      },
-      title: {
-        type: 'string',
-        description: 'Updated todo item title'
-      },
-      completed: {
-        type: 'boolean',
-        description: 'Updated completion status'
-      },
-      createdAt: {
-        type: 'string',
-        description: 'Creation timestamp'
-      },
-      updatedAt: {
-        type: 'string',
-        description: 'Last update timestamp'
-      }
-    }
-  }
+  response: {}
 }

--- a/src/__test__/decorators/todo-api.decorator.spec.ts
+++ b/src/__test__/decorators/todo-api.decorator.spec.ts
@@ -28,7 +28,6 @@ describe('Todo API Decorators', () => {
       expect(metadata?.method).toEqual('POST')
       expect(metadata?.description).toEqual(mock.description)
       expect(metadata?.request).toEqual(mock.request)
-      expect(metadata?.response).toEqual(mock.response)
     })
   })
 
@@ -43,7 +42,6 @@ describe('Todo API Decorators', () => {
       expect(metadata?.method).toEqual('PATCH')
       expect(metadata?.description).toEqual(mock.description)
       expect(metadata?.request).toEqual(mock.request)
-      expect(metadata?.response).toEqual(mock.response)
     })
   })
 
@@ -58,7 +56,6 @@ describe('Todo API Decorators', () => {
       expect(metadata?.method).toEqual('DELETE')
       expect(metadata?.description).toEqual(mock.description)
       expect(metadata?.request).toEqual(mock.request)
-      expect(metadata?.response).toEqual(mock.response)
     })
   })
 })

--- a/src/__test__/generators/controller-extractor.spec.ts
+++ b/src/__test__/generators/controller-extractor.spec.ts
@@ -3,6 +3,7 @@ import { ControllerExtractor } from '../../generators'
 import { ERROR_MESSAGES } from '../../constants'
 import { TodoController } from '../__fixtures__/controllers'
 import { getControllersMockData } from '../__fixtures__/mocks'
+import { CommonUtils, MetadataExtractor } from '../../'
 
 describe('Testing ControllerExtractor extract right data', () => {
   let controllerExtractor: ControllerExtractor
@@ -54,9 +55,10 @@ describe('Testing ControllerExtractor extract right data', () => {
   it('should extract controller information correctly', async () => {
     mockDiscoveryService.getControllers.mockReturnValue([mockWrapper])
     const result = await controllerExtractor.extract()
+    const controllerName = MetadataExtractor.extractControllerPath(TodoController)
 
     expect(result).toHaveLength(1)
-    expect(result[0].controllerName).toEqual(TodoController.name)
+    expect(result[0].controllerName).toEqual(CommonUtils.camelToPascalCase(controllerName))
     expect(result[0].description).toEqual(getControllersMockData('todoController').description)
     expect(result[0].basePath).toEqual('todo')
   })

--- a/src/interfaces/decorator.interface.ts
+++ b/src/interfaces/decorator.interface.ts
@@ -1,4 +1,4 @@
-import type { ApiProperty, ApiResponse } from '.'
+import type { ApiProperty } from '.'
 
 type MetadataPropertiesKeys = 'body' | 'query' | 'params' | 'response'
 
@@ -25,7 +25,6 @@ export interface EndpointDecoratorMetadata<P extends DefaultMetadataProperties> 
     }
   }
   response?: {
-    properties?: P['response'] extends string ? Record<P['response'], ApiResponse> : never
     example?: P['response'] extends string ? Record<P['response'], any> | Array<Record<P['response'], any>> : never
   }
   deprecated?: boolean

--- a/src/interfaces/endpoint.interface.ts
+++ b/src/interfaces/endpoint.interface.ts
@@ -15,8 +15,6 @@ export interface ApiEndpointMetadata {
   description: string
   request?: ApiRequest
   response?: ApiResponse
-  requestExample?: any
-  responseExample?: any
   deprecated?: boolean
   tags?: string[]
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -26,7 +26,6 @@ export interface ApiResponse {
   type: string
   description?: string
   example?: any
-  properties?: Record<string, Omit<ApiProperty, 'required'>>
 }
 
 export * from './endpoint.interface'


### PR DESCRIPTION
1. Refactor API response properties
2. Refector test code

Simplification of mock data responses:

* [`src/__test__/__fixtures__/mocks/todo/createTodo.mock.ts`](diffhunk://#diff-32726926e45a3423ff7f7720634fca3ac1b2707f349afe9ef53ab42ee00da298L13-L36): Removed detailed properties from the `response` object.
* [`src/__test__/__fixtures__/mocks/todo/deleteTodo.mock.ts`](diffhunk://#diff-80f5f2559032c3f87143ef56edf4d063d6db9a36d47af24b20437bb5f95357b8L14-R14): Simplified the `response` object by removing detailed properties.
* [`src/__test__/__fixtures__/mocks/todo/getAllTodos.mock.ts`](diffhunk://#diff-7d7f626e08ab4e6ddde9cf4e4775b4567e94e707b2de08789af2a89c23062564L4-L25): Removed detailed properties from the `response` object.
* [`src/__test__/__fixtures__/mocks/todo/updateTodo.mock.ts`](diffhunk://#diff-0a7aa26aa07fc62d6c3193c23e6859bbd3ee8c5d7631248396cb805a382247a6L28-R28): Simplified the `response` object by removing detailed properties.

Updates to test files:

* [`src/__test__/decorators/todo-api.decorator.spec.ts`](diffhunk://#diff-ce59b444a3ce908df16243f213ed2aa09fb241e06e463bc799c153846ca3f251L31): Removed assertions for `response` in multiple test cases to match the simplified mock data. [[1]](diffhunk://#diff-ce59b444a3ce908df16243f213ed2aa09fb241e06e463bc799c153846ca3f251L31) [[2]](diffhunk://#diff-ce59b444a3ce908df16243f213ed2aa09fb241e06e463bc799c153846ca3f251L46) [[3]](diffhunk://#diff-ce59b444a3ce908df16243f213ed2aa09fb241e06e463bc799c153846ca3f251L61)
* [`src/__test__/generators/controller-extractor.spec.ts`](diffhunk://#diff-978bece4dc3bbe506228a8bbdbf37667a480fb8a613b9890e2da299f032d4047R6): Added imports for `CommonUtils` and `MetadataExtractor`, and updated the test to use `CommonUtils.camelToPascalCase` for `controllerName`. [[1]](diffhunk://#diff-978bece4dc3bbe506228a8bbdbf37667a480fb8a613b9890e2da299f032d4047R6) [[2]](diffhunk://#diff-978bece4dc3bbe506228a8bbdbf37667a480fb8a613b9890e2da299f032d4047R58-R61)

Changes to interfaces:

* [`src/interfaces/decorator.interface.ts`](diffhunk://#diff-fdca2ab58e5c74cf32110041671f52f858e7eb35f20cd2d06761b8f6a41dbeb8L1-R1): Removed unused import `ApiResponse` and the `properties` field from the `response` object. [[1]](diffhunk://#diff-fdca2ab58e5c74cf32110041671f52f858e7eb35f20cd2d06761b8f6a41dbeb8L1-R1) [[2]](diffhunk://#diff-fdca2ab58e5c74cf32110041671f52f858e7eb35f20cd2d06761b8f6a41dbeb8L28)
* [`src/interfaces/endpoint.interface.ts`](diffhunk://#diff-68549b615faf99c6a7aa00327eb205777f07702b5e46eeaffc3015c81d85eefdL18-L19): Removed `requestExample` and `responseExample` fields.
* [`src/interfaces/index.ts`](diffhunk://#diff-2433a58dd5b382f3ef0faf44d5ab97bf79428a0a1452d72934c9ca3c77a237bcL29): Removed the `properties` field from the `ApiResponse` interface.