### PR TITLE
Refactor API DocsGenerator and add new metadata interface

### DIFF
--- a/src/__test__/decorators/todo-api.decorator.spec.ts
+++ b/src/__test__/decorators/todo-api.decorator.spec.ts
@@ -5,57 +5,53 @@ import { createTodo, deleteTodo, getAllTodos, updateTodo } from '../__fixtures__
 describe('Todo API Decorators', () => {
   describe('DocsGetAllTodos', () => {
     it('should call with correct metadata from mock', () => {
-      const mock = getAllTodos
       const prototype = TodoController.prototype
       const methodNames = MetadataExtractor.extractMethodNames(prototype) as any[]
       const getAllTodosMethod = methodNames.find((method) => method === 'getAllTodos')
       const metadata = MetadataExtractor.extractEndpointMetadata(prototype, getAllTodosMethod)
 
       expect(metadata?.method).toEqual('GET')
-      expect(metadata?.description).toEqual(mock.description)
-      expect(metadata?.response).toEqual(mock.response)
+      expect(metadata?.description).toEqual(getAllTodos.description)
+      expect(metadata?.response).toEqual(getAllTodos.response)
     })
   })
 
   describe('DocsCreateTodo', () => {
     it('should call with correct metadata from mock', () => {
-      const mock = createTodo
       const prototype = TodoController.prototype
       const methodNames = MetadataExtractor.extractMethodNames(prototype) as any[]
       const createTodoMethod = methodNames.find((method) => method === 'createTodo')
       const metadata = MetadataExtractor.extractEndpointMetadata(prototype, createTodoMethod)
 
       expect(metadata?.method).toEqual('POST')
-      expect(metadata?.description).toEqual(mock.description)
-      expect(metadata?.request).toEqual(mock.request)
+      expect(metadata?.description).toEqual(createTodo.description)
+      expect(metadata?.request).toEqual(createTodo.request)
     })
   })
 
   describe('DocsUpdateTodo', () => {
     it('should call with correct metadata from mock', () => {
-      const mock = updateTodo
       const prototype = TodoController.prototype
       const methodNames = MetadataExtractor.extractMethodNames(prototype) as any[]
       const updateTodoMethod = methodNames.find((method) => method === 'updateTodo')
       const metadata = MetadataExtractor.extractEndpointMetadata(prototype, updateTodoMethod)
 
       expect(metadata?.method).toEqual('PATCH')
-      expect(metadata?.description).toEqual(mock.description)
-      expect(metadata?.request).toEqual(mock.request)
+      expect(metadata?.description).toEqual(updateTodo.description)
+      expect(metadata?.request).toEqual(updateTodo.request)
     })
   })
 
   describe('DocsDeleteTodo', () => {
     it('should call with correct metadata from mock', () => {
-      const mock = deleteTodo
       const prototype = TodoController.prototype
       const methodNames = MetadataExtractor.extractMethodNames(prototype) as any[]
       const deleteTodoMethod = methodNames.find((method) => method === 'deleteTodo')
       const metadata = MetadataExtractor.extractEndpointMetadata(prototype, deleteTodoMethod)
 
       expect(metadata?.method).toEqual('DELETE')
-      expect(metadata?.description).toEqual(mock.description)
-      expect(metadata?.request).toEqual(mock.request)
+      expect(metadata?.description).toEqual(deleteTodo.description)
+      expect(metadata?.request).toEqual(deleteTodo.request)
     })
   })
 })

--- a/src/__test__/generators/api-docs.generator.spec.ts
+++ b/src/__test__/generators/api-docs.generator.spec.ts
@@ -1,6 +1,7 @@
 import { DiscoveryService } from '@nestjs/core'
 import { ApiDocsGenerator } from '../../generators'
 import { ControllerExtractor, DocsWriter } from '../../generators'
+import { ReceivedMetadata } from 'src/interfaces'
 
 jest.mock('../../utils/file-manager')
 jest.mock('../../generators/controller-extractor')
@@ -12,10 +13,11 @@ describe('Testing that ApiDocsGenerator creates json files with the correct data
   let mockControllerExtractor: jest.Mocked<ControllerExtractor>
   let mockDocsWriter: jest.Mocked<DocsWriter>
 
-  const testMetadata = {
+  const testMetadata: ReceivedMetadata = {
     name: 'test-api',
     description: 'Test API Description',
-    version: '1.0.0'
+    version: '1.0.0',
+    serverUrl: 'http://localhost:3000'
   }
 
   beforeEach(() => {

--- a/src/generators/api-docs.generator.ts
+++ b/src/generators/api-docs.generator.ts
@@ -1,20 +1,14 @@
 import type { DiscoveryService } from '@nestjs/core'
-import { FileManager } from '../utils'
 import { ControllerExtractor, DocsWriter } from '.'
-
-export interface ProjectMetadata {
-  name: string
-  description: string
-  version: string
-  routes: string[]
-}
+import { ProjectMetadata, ReceivedMetadata } from '../interfaces'
+import { FileManager } from '../utils'
 
 export class ApiDocsGenerator {
   private readonly metadata: ProjectMetadata
   private readonly writer: DocsWriter
   private readonly controllerExtractor: ControllerExtractor
 
-  constructor(metadata: Omit<ProjectMetadata, 'routes'>, outputPath: string, discoveryService: DiscoveryService, targetFolder?: string) {
+  constructor(metadata: ReceivedMetadata, outputPath: string, discoveryService: DiscoveryService, targetFolder?: string) {
     this.metadata = { ...metadata, routes: [] }
     this.writer = new DocsWriter(new FileManager(outputPath, targetFolder))
     this.controllerExtractor = new ControllerExtractor(discoveryService)

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -31,3 +31,4 @@ export interface ApiResponse {
 export * from './endpoint.interface'
 export * from './documentation.interface'
 export * from './decorator.interface'
+export * from './metadata.interface'

--- a/src/interfaces/metadata.interface.ts
+++ b/src/interfaces/metadata.interface.ts
@@ -1,0 +1,10 @@
+export interface ReceivedMetadata {
+  name: string
+  description: string
+  version: string
+  serverUrl: string
+}
+
+export interface ProjectMetadata extends ReceivedMetadata {
+  routes: string[]
+}

--- a/src/utils/metadata-extractor.ts
+++ b/src/utils/metadata-extractor.ts
@@ -24,7 +24,7 @@ export class MetadataExtractor {
     const method = this.convertMethodValueToString(methodValue)
 
     return {
-      path,
+      path: path === '/' ? '' : `/${path}`,
       method,
       name: CommonUtils.pascalCaseWithSpaces(methodName),
       ...metadata


### PR DESCRIPTION
1. Refactor API documentation generation
2. Refactor API DocsGenerator and add new metadata interface
3. Refactor path in MetadataExtractor class

### Metadata Interface Updates:
* Added new `ReceivedMetadata` interface and updated `ProjectMetadata` to extend from it in `src/interfaces/metadata.interface.ts`.

### ApiDocsGenerator Class Modifications:
* Updated the constructor of `ApiDocsGenerator` to use `ReceivedMetadata` instead of a partial `ProjectMetadata` in `src/generators/api-docs.generator.ts`.

### Test Updates:
* Updated test metadata to use the `ReceivedMetadata` type in `src/__test__/generators/api-docs.generator.spec.ts`.
* Refactored tests to directly use imported functions instead of intermediate variables in `src/__test__/decorators/todo-api.decorator.spec.ts`.

### Metadata Extraction Logic:
* Modified the `MetadataExtractor` class to adjust the `path` value formatting in `src/utils/metadata-extractor.ts`.

### Import Adjustments:
* Added export for `metadata.interface` in `src/interfaces/index.ts`.