### PR TITLE
Add headers property to EndpointDecoratorMetadata

### DIFF
--- a/src/__test__/__fixtures__/decorators/todo-endpoints.decorator.ts
+++ b/src/__test__/__fixtures__/decorators/todo-endpoints.decorator.ts
@@ -4,12 +4,7 @@ import { getMockData } from '../mocks'
 
 export const DocsGetAllTodos = () => {
   const mock = getMockData('todo', 'getAllTodos')
-
-  const metadata: EndpointDecoratorMetadata<{
-    response: 'id' | 'title' | 'completed' | 'createdAt' | 'updatedAt'
-  }> = mock
-
-  return ApiDocsEndpoint(metadata)
+  return ApiDocsEndpoint(mock)
 }
 
 export const DocsGetAllTodosByDates = () => {

--- a/src/__test__/__fixtures__/mocks/todo/getAllTodos.mock.ts
+++ b/src/__test__/__fixtures__/mocks/todo/getAllTodos.mock.ts
@@ -1,5 +1,19 @@
-export const getAllTodos = {
+import { EndpointDecoratorMetadata } from '../../../../interfaces'
+
+export const getAllTodos: EndpointDecoratorMetadata<{
+  headers: 'Content-Type'
+  response: 'id' | 'title' | 'completed' | 'createdAt' | 'updatedAt'
+}> = {
   description: 'Get all todo items',
+  request: {
+    headers: {
+      properties: {
+        'Content-Type': {
+          default: 'application/json'
+        }
+      }
+    }
+  },
   response: {
     example: [
       {

--- a/src/interfaces/decorator.interface.ts
+++ b/src/interfaces/decorator.interface.ts
@@ -1,6 +1,6 @@
-import type { ApiProperty } from '.'
+import type { ApiHeaderProperty, ApiProperty } from '.'
 
-type MetadataPropertiesKeys = 'body' | 'query' | 'params' | 'response'
+type MetadataPropertiesKeys = 'body' | 'query' | 'params' | 'response' | 'headers'
 
 export interface ApiDocsControllerMetadata {
   description?: string
@@ -22,6 +22,9 @@ export interface EndpointDecoratorMetadata<P extends DefaultMetadataProperties> 
     }
     params?: {
       properties: P['params'] extends string ? Record<P['params'], ApiProperty> : never
+    }
+    headers?: {
+      properties: P['headers'] extends string ? Record<P['headers'], ApiHeaderProperty> : never
     }
   }
   response?: {

--- a/src/interfaces/documentation.interface.ts
+++ b/src/interfaces/documentation.interface.ts
@@ -13,11 +13,6 @@ export interface ApiDocumentation {
     title: string
     description?: string
     version: string
-    contact?: {
-      name?: string
-      email?: string
-      url?: string
-    }
   }
   servers: Array<{
     url: string

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -5,21 +5,27 @@ export interface ApiProperty {
   description: string
   required: boolean
   example?: any
-  enum?: string[]
-  items?: ApiProperty
 }
 
 export interface ApiParameters {
   type: string
   properties: Record<string, ApiProperty>
-  required?: string[]
+}
+
+export interface ApiHeaderProperty {
+  default?: string
+  required?: boolean
+}
+
+export interface ApiHeadersParameters {
+  properties: Record<string, ApiHeaderProperty>
 }
 
 export interface ApiRequest {
   body?: ApiParameters
   query?: ApiParameters
   params?: ApiParameters
-  headers?: ApiParameters
+  headers?: ApiHeadersParameters
 }
 
 export interface ApiResponse {


### PR DESCRIPTION
1. Add headers property to EndpointDecoratorMetadata
2. Refactor API documentation interface and headers parameters
3. Refactor todo-endpoints.decorator and getAllTodos.mock

Enhancements to API metadata:

* [`src/interfaces/decorator.interface.ts`](diffhunk://#diff-fdca2ab58e5c74cf32110041671f52f858e7eb35f20cd2d06761b8f6a41dbeb8L1-R3): Added support for `headers` metadata in the `EndpointDecoratorMetadata` interface and the `MetadataPropertiesKeys` type. [[1]](diffhunk://#diff-fdca2ab58e5c74cf32110041671f52f858e7eb35f20cd2d06761b8f6a41dbeb8L1-R3) [[2]](diffhunk://#diff-fdca2ab58e5c74cf32110041671f52f858e7eb35f20cd2d06761b8f6a41dbeb8R26-R28)
* [`src/interfaces/index.ts`](diffhunk://#diff-2433a58dd5b382f3ef0faf44d5ab97bf79428a0a1452d72934c9ca3c77a237bcL8-R28): Introduced `ApiHeaderProperty` and `ApiHeadersParameters` interfaces to define header properties and updated `ApiRequest` to use `ApiHeadersParameters` for headers.

Codebase simplification:

* [`src/__test__/__fixtures__/decorators/todo-endpoints.decorator.ts`](diffhunk://#diff-e44e1e5718cafdd4c705502d7ba86dc8488d744b24daa84908d080c6cce11586L7-R7): Simplified the `DocsGetAllTodos` function by directly returning the `mock` object in `ApiDocsEndpoint`.
* [`src/__test__/__fixtures__/mocks/todo/getAllTodos.mock.ts`](diffhunk://#diff-7d7f626e08ab4e6ddde9cf4e4775b4567e94e707b2de08789af2a89c23062564L1-R16): Refactored the `getAllTodos` mock to include header metadata and used the `EndpointDecoratorMetadata` type.

Removal of unused properties:

* [`src/interfaces/documentation.interface.ts`](diffhunk://#diff-69fe94285b2d2bb113abbbd015b54c829884a40074097cfd45fba90dd795b46aL16-L20): Removed the unused `contact` property from the `ApiDocumentation` interface.