### PR TITLE
Refactor todo-endpoints decorator and mocks

### DIFF
--- a/src/__test__/__fixtures__/decorators/todo-endpoints.decorator.ts
+++ b/src/__test__/__fixtures__/decorators/todo-endpoints.decorator.ts
@@ -19,13 +19,7 @@ export const DocsGetAllTodosByDates = () => {
 
 export const DocsCreateTodo = () => {
   const mock = getMockData('todo', 'createTodo')
-
-  const metadata: EndpointDecoratorMetadata<{
-    body: 'title'
-    response: 'id' | 'title' | 'completed' | 'createdAt' | 'updatedAt'
-  }> = mock
-
-  return ApiDocsEndpoint(metadata)
+  return ApiDocsEndpoint(mock)
 }
 
 export const DocsUpdateTodo = () => {

--- a/src/__test__/__fixtures__/decorators/todo-endpoints.decorator.ts
+++ b/src/__test__/__fixtures__/decorators/todo-endpoints.decorator.ts
@@ -1,4 +1,3 @@
-import { EndpointDecoratorMetadata } from '../../../interfaces'
 import { ApiDocsEndpoint } from '../../../decorators'
 import { getMockData } from '../mocks'
 
@@ -9,12 +8,7 @@ export const DocsGetAllTodos = () => {
 
 export const DocsGetAllTodosByDates = () => {
   const mock = getMockData('todo', 'getAllTodosByDates')
-
-  const metadata: EndpointDecoratorMetadata<{
-    response: 'data' | 'total'
-  }> = mock
-
-  return ApiDocsEndpoint(metadata)
+  return ApiDocsEndpoint(mock)
 }
 
 export const DocsCreateTodo = () => {

--- a/src/__test__/__fixtures__/decorators/todo-endpoints.decorator.ts
+++ b/src/__test__/__fixtures__/decorators/todo-endpoints.decorator.ts
@@ -36,11 +36,5 @@ export const DocsUpdateTodo = () => {
 
 export const DocsDeleteTodo = () => {
   const mock = getMockData('todo', 'deleteTodo')
-
-  const metadata: EndpointDecoratorMetadata<{
-    params: 'id'
-    response: 'success'
-  }> = mock
-
-  return ApiDocsEndpoint(metadata)
+  return ApiDocsEndpoint(mock)
 }

--- a/src/__test__/__fixtures__/decorators/todo-endpoints.decorator.ts
+++ b/src/__test__/__fixtures__/decorators/todo-endpoints.decorator.ts
@@ -24,14 +24,7 @@ export const DocsCreateTodo = () => {
 
 export const DocsUpdateTodo = () => {
   const mock = getMockData('todo', 'updateTodo')
-
-  const metadata: EndpointDecoratorMetadata<{
-    params: 'id'
-    body: 'title' | 'completed'
-    response: 'id' | 'title' | 'completed' | 'createdAt' | 'updatedAt'
-  }> = mock
-
-  return ApiDocsEndpoint(metadata)
+  return ApiDocsEndpoint(mock)
 }
 
 export const DocsDeleteTodo = () => {

--- a/src/__test__/__fixtures__/mocks/todo/createTodo.mock.ts
+++ b/src/__test__/__fixtures__/mocks/todo/createTodo.mock.ts
@@ -1,4 +1,9 @@
-export const createTodo = {
+import { EndpointDecoratorMetadata } from '../../../../interfaces'
+
+export const createTodo: EndpointDecoratorMetadata<{
+  body: 'title'
+  headers: 'Content-Type'
+}> = {
   description: 'Create a new todo item',
   request: {
     body: {
@@ -7,6 +12,13 @@ export const createTodo = {
           type: 'string',
           description: 'Todo item title',
           required: true
+        }
+      }
+    },
+    headers: {
+      properties: {
+        'Content-Type': {
+          default: 'application/json'
         }
       }
     }

--- a/src/__test__/__fixtures__/mocks/todo/deleteTodo.mock.ts
+++ b/src/__test__/__fixtures__/mocks/todo/deleteTodo.mock.ts
@@ -1,4 +1,9 @@
-export const deleteTodo = {
+import { EndpointDecoratorMetadata } from '../../../../interfaces'
+
+export const deleteTodo: EndpointDecoratorMetadata<{
+  params: 'id'
+  response: 'success'
+}> = {
   description: 'Delete a todo item',
   request: {
     params: {

--- a/src/__test__/__fixtures__/mocks/todo/getAllTodos.mock.ts
+++ b/src/__test__/__fixtures__/mocks/todo/getAllTodos.mock.ts
@@ -1,19 +1,10 @@
 import { EndpointDecoratorMetadata } from '../../../../interfaces'
 
 export const getAllTodos: EndpointDecoratorMetadata<{
-  headers: 'Content-Type'
   response: 'id' | 'title' | 'completed' | 'createdAt' | 'updatedAt'
 }> = {
   description: 'Get all todo items',
-  request: {
-    headers: {
-      properties: {
-        'Content-Type': {
-          default: 'application/json'
-        }
-      }
-    }
-  },
+  request: {},
   response: {
     example: [
       {

--- a/src/__test__/__fixtures__/mocks/todo/getAllTodosByDates.mock.ts
+++ b/src/__test__/__fixtures__/mocks/todo/getAllTodosByDates.mock.ts
@@ -1,4 +1,8 @@
-export const getAllTodosByDates = {
+import { EndpointDecoratorMetadata } from '../../../../interfaces'
+
+export const getAllTodosByDates: EndpointDecoratorMetadata<{
+  response: 'data' | 'total'
+}> = {
   description: 'Get all todo items by dates',
   response: {
     example: {

--- a/src/__test__/__fixtures__/mocks/todo/updateTodo.mock.ts
+++ b/src/__test__/__fixtures__/mocks/todo/updateTodo.mock.ts
@@ -1,6 +1,20 @@
-export const updateTodo = {
+import { EndpointDecoratorMetadata } from '../../../../interfaces'
+
+export const updateTodo: EndpointDecoratorMetadata<{
+  params: 'id'
+  body: 'title' | 'completed'
+  headers: 'Content-Type'
+  response: 'id' | 'title' | 'completed' | 'createdAt' | 'updatedAt'
+}> = {
   description: 'Update a todo item',
   request: {
+    headers: {
+      properties: {
+        'Content-Type': {
+          default: 'application/json'
+        }
+      }
+    },
     params: {
       properties: {
         id: {


### PR DESCRIPTION
1. Refactor todo-endpoints decorator and mocks

Refactoring metadata handling:

* [`src/__test__/__fixtures__/decorators/todo-endpoints.decorator.ts`](diffhunk://#diff-e44e1e5718cafdd4c705502d7ba86dc8488d744b24daa84908d080c6cce11586L12-R26): Removed redundant `EndpointDecoratorMetadata` definitions and directly used mock data in `ApiDocsEndpoint` calls.

Consolidating metadata in mock data files:

* [`src/__test__/__fixtures__/mocks/todo/createTodo.mock.ts`](diffhunk://#diff-32726926e45a3423ff7f7720634fca3ac1b2707f349afe9ef53ab42ee00da298L1-R6): Added `EndpointDecoratorMetadata` type to `createTodo` mock and included headers metadata. [[1]](diffhunk://#diff-32726926e45a3423ff7f7720634fca3ac1b2707f349afe9ef53ab42ee00da298L1-R6) [[2]](diffhunk://#diff-32726926e45a3423ff7f7720634fca3ac1b2707f349afe9ef53ab42ee00da298R17-R23)
* [`src/__test__/__fixtures__/mocks/todo/deleteTodo.mock.ts`](diffhunk://#diff-80f5f2559032c3f87143ef56edf4d063d6db9a36d47af24b20437bb5f95357b8L1-R6): Added `EndpointDecoratorMetadata` type to `deleteTodo` mock.
* [`src/__test__/__fixtures__/mocks/todo/getAllTodos.mock.ts`](diffhunk://#diff-7d7f626e08ab4e6ddde9cf4e4775b4567e94e707b2de08789af2a89c23062564L4-R7): Removed headers metadata from `getAllTodos` mock and simplified the request object.
* [`src/__test__/__fixtures__/mocks/todo/getAllTodosByDates.mock.ts`](diffhunk://#diff-5f1b5f24ce64e6fd7baf10706fc00502b5796fc719335eadec56209cd5695a31L1-R5): Added `EndpointDecoratorMetadata` type to `getAllTodosByDates` mock.
* [`src/__test__/__fixtures__/mocks/todo/updateTodo.mock.ts`](diffhunk://#diff-0a7aa26aa07fc62d6c3193c23e6859bbd3ee8c5d7631248396cb805a382247a6L1-R17): Added `EndpointDecoratorMetadata` type to `updateTodo` mock and included headers metadata.