### PR TITLE
Update ApiHeaderProperty interface to include credentials field

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -13,8 +13,10 @@ export interface ApiParameters {
 }
 
 export interface ApiHeaderProperty {
-  default?: string
-  required?: boolean
+  default: string
+  credentials?: {
+    type: 'Bearer' | 'Basic' | 'custom'
+  }
 }
 
 export interface ApiHeadersParameters {


### PR DESCRIPTION
This pull request includes changes to the `ApiHeaderProperty` interface in the `src/interfaces/index.ts` file to enhance the handling of API headers. The most important changes include making the `default` property mandatory and adding a new optional `credentials` property.

Enhancements to API header handling:

* [`src/interfaces/index.ts`](diffhunk://#diff-2433a58dd5b382f3ef0faf44d5ab97bf79428a0a1452d72934c9ca3c77a237bcL16-R19): Modified the `ApiHeaderProperty` interface to make the `default` property mandatory and added an optional `credentials` property to support different types of authentication.