### PR TITLE
Update package.json with new workspace path

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/doke-nest"
   ],
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.0.0",


### PR DESCRIPTION
This pull request includes a minor change to the `package.json` file. The change updates the workspace configuration to specify a particular package.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L9-R9): Changed the workspace configuration from `"packages/*"` to `"packages/doke-nest"`.