### PR TITLE
Remove Extension Version in readme cause confilct .git

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,3 @@ API documentation generator for NestJS applications with beautiful UI 🎨
 - Easy to use and integrate
 - Automatic metadata extraction
 - Customizable themes and layouts
-
-## Extension version
-
-- Prettier Code formatter v10.4.0
-- ESLint - v2.4.4


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change removes the "Extension version" section, which listed versions for Prettier Code formatter and ESLint.

Changes in `README.md`:

* Removed the "Extension version" section, which included version details for Prettier Code formatter and ESLint.