### PR TITLE
Feat/doke UI yarn berry

### DIFF
--- a/packages/doke-ui/.vscode/extensions.json
+++ b/packages/doke-ui/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "arcanis.vscode-zipfs",
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
   ]
 }

--- a/packages/doke-ui/.yarn/sdks/prettier/bin/prettier.cjs
+++ b/packages/doke-ui/.yarn/sdks/prettier/bin/prettier.cjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, register} = require(`module`);
+const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
+
+const relPnpApiPath = "../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
+const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require prettier/bin/prettier.cjs
+    require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
+  }
+}
+
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
+// Defer to the real prettier/bin/prettier.cjs your application uses
+module.exports = wrapWithUserWrapper(absRequire(`prettier/bin/prettier.cjs`));

--- a/packages/doke-ui/.yarn/sdks/prettier/index.cjs
+++ b/packages/doke-ui/.yarn/sdks/prettier/index.cjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, register} = require(`module`);
+const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
+
+const relPnpApiPath = "../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
+const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require prettier
+    require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
+  }
+}
+
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
+// Defer to the real prettier your application uses
+module.exports = wrapWithUserWrapper(absRequire(`prettier`));

--- a/packages/doke-ui/.yarn/sdks/prettier/package.json
+++ b/packages/doke-ui/.yarn/sdks/prettier/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "prettier",
+  "version": "3.0.3-sdk",
+  "main": "./index.cjs",
+  "type": "commonjs",
+  "bin": "./bin/prettier.cjs"
+}

--- a/packages/doke-ui/package.json
+++ b/packages/doke-ui/package.json
@@ -23,6 +23,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.2.0",
     "postcss": "^8",
+    "prettier": "3.0.3",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   },

--- a/packages/doke-ui/yarn.lock
+++ b/packages/doke-ui/yarn.lock
@@ -1519,6 +1519,7 @@ __metadata:
     eslint-config-next: "npm:15.2.0"
     next: "npm:15.2.0"
     postcss: "npm:^8"
+    prettier: "npm:3.0.3"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     react-json-view: "npm:^1.21.3"
@@ -3626,6 +3627,15 @@ __metadata:
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
   checksum: 10c0/b00d617431e7886c520a6f498a2e14c75ec58f6d93ba48c3b639cf241b54232d90daa05d83a9e9b9fef6baa63cb7e1e4602c2372fea5bc169668401eb127d0cd
+  languageName: node
+  linkType: hard
+
+"prettier@npm:3.0.3":
+  version: 3.0.3
+  resolution: "prettier@npm:3.0.3"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/f950887bc03c5b970d8c6dd129364acfbbc61e7b46aec5d5ce17f4adf6404e2ef43072c98b51c4786e0eaca949b307d362a773fd47502862d754b5a328fa2b26
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request includes several changes to the `doke-ui` package, primarily focused on integrating Prettier for code formatting and ensuring compatibility with the Yarn Plug'n'Play (PnP) environment. The most important changes are listed below:

### Integration of Prettier:

* [`packages/doke-ui/.vscode/extensions.json`](diffhunk://#diff-1c31d8dad5edff06cec53bef99b27779b36d466ffd3fa5a747c0d0537d885b00L4-R5): Added the Prettier extension recommendation for VS Code.
* [`packages/doke-ui/.yarn/sdks/prettier/index.cjs`](diffhunk://#diff-1559ff347d5d9d137a5a1ee3a934933458bd7757bbed14016bb1a88c2485d591R1-R32): Added a new script to set up Prettier with Yarn PnP, ensuring compatibility and proper module resolution.
* [`packages/doke-ui/.yarn/sdks/prettier/package.json`](diffhunk://#diff-bbef05ab630ae5d91f3f4db2085a49510425b1cce1e79a3fb9d8cb501281cc79R1-R7): Created a package.json file for the Prettier SDK, specifying the version and main entry point.
* [`packages/doke-ui/package.json`](diffhunk://#diff-11f4a73d9aebb14d7ad11c025de17fc35537e2883b924078c7c9f95a3b1e273aR26): Added Prettier as a development dependency.