### PR TITLE
Add .yarnrc.yml file with nodeLinker configuration in doke-ui

### DIFF
--- a/packages/doke-ui/.yarnrc.yml
+++ b/packages/doke-ui/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
This pull request includes a small change to the `packages/doke-ui/.yarnrc.yml` file. The change sets the `nodeLinker` option to use `node-modules`.