### PR TITLE
Update Dockerfile for doke-ui package

### DIFF
--- a/packages/doke-cli/package.json
+++ b/packages/doke-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doke-cli",
-  "version": "5.1.0",
+  "version": "1.0.0",
   "keywords": [
     "nextjs",
     "doke"

--- a/packages/doke-ui/Dockerfile
+++ b/packages/doke-ui/Dockerfile
@@ -1,20 +1,26 @@
-FROM node:20.12-buster-slim AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR     /app
 RUN     corepack enable
 
 COPY    ./.yarn /app/.yarn
-COPY    ./.yarn/cache /app/.yarn/cache
 COPY    ./.yarnrc.yml /app/.yarnrc.yml
 COPY    ./yarn.lock /app/yarn.lock
 COPY    ./package.json /app/package.json
-COPY    ./.pnp.cjs /app/.pnp.cjs
-COPY    ./.pnp.loader.mjs /app/.pnp.loader.mjs
 
 RUN     yarn install --immutable
-COPY    . /app
+COPY    . .
 RUN     yarn build
 
-CMD     ["tail", "-f", "/dev/null"]
 
+FROM node:20-alpine AS runner
 
+WORKDIR     /app
+COPY    --from=builder /app/next.config.ts ./
+COPY    --from=builder /app/.next/standalone ./
+COPY    --from=builder /app/.next/standalone/.next ./.next
+COPY    --from=builder /app/.next/static ./.next/static
+
+EXPOSE    3001 
+ENV     PORT=3001
+CMD     ["node", "server.js"]


### PR DESCRIPTION
This pull request makes significant changes to the `packages/doke-ui/Dockerfile` to streamline the build process and improve the Docker image. The most important changes include switching the base image, simplifying the file copying process, and configuring the runner stage.

Dockerfile improvements:

* Changed the base image from `node:20.12-buster-slim` to `node:20-alpine` for both the builder and runner stages, which reduces the image size and improves build times.
* Removed unnecessary file copies (`.yarn/cache`, `.pnp.cjs`, `.pnp.loader.mjs`) and simplified the `COPY` command to use `COPY . .`.
* Added a new runner stage with necessary configurations, including copying build artifacts from the builder stage, setting the `PORT` environment variable, and exposing port 3001.
* Removed the `CMD ["tail", "-f", "/dev/null"]` command and added `CMD ["node", "server.js"]` to start the server.