### PR TITLE
Add doke-cli commands and update doke-ui .gitignore

### DIFF
--- a/packages/doke-cli/src/index.ts
+++ b/packages/doke-cli/src/index.ts
@@ -1,0 +1,24 @@
+import { Command } from 'commander'
+import chalk from 'chalk'
+
+const program = new Command()
+
+program.name('doke-cli').version('1.0.0', '-v, --version').description('Create relative doke just in time')
+
+program
+  .command('check-docker')
+  .description('Docker 설치 및 실행 상태 확인')
+  .action(async () => {
+    console.log(chalk.blue('Docker 환경 확인 중...'))
+  })
+
+program
+  .command('init')
+  .description('프로젝트 초기화 및 Docker 환경 확인')
+  .action(async () => {
+    console.log(chalk.blue('프로젝트 초기화 중...'))
+    console.log(chalk.blue('Docker 환경 확인 중...'))
+    console.log(chalk.green('✅ 프로젝트 초기화가 완료되었습니다.'))
+  })
+
+program.parse(process.argv)

--- a/packages/doke-cli/src/index.ts
+++ b/packages/doke-cli/src/index.ts
@@ -6,13 +6,6 @@ const program = new Command()
 program.name('doke-cli').version('1.0.0', '-v, --version').description('Create relative doke just in time')
 
 program
-  .command('check-docker')
-  .description('Docker 설치 및 실행 상태 확인')
-  .action(async () => {
-    console.log(chalk.blue('Docker 환경 확인 중...'))
-  })
-
-program
   .command('init')
   .description('프로젝트 초기화 및 Docker 환경 확인')
   .action(async () => {

--- a/packages/doke-ui/.gitignore
+++ b/packages/doke-ui/.gitignore
@@ -15,7 +15,7 @@
 /coverage
 
 # next.js
-/.next/
+/.next/*
 /out/
 
 # production


### PR DESCRIPTION
This pull request introduces a new command-line interface (CLI) for the `doke-cli` package and updates the `.gitignore` file in the `doke-ui` package. The most important changes include the addition of the CLI functionality and the update to the `.gitignore` file to ignore all files and directories under `.next`.

New CLI functionality:

* [`packages/doke-cli/src/index.ts`](diffhunk://#diff-b85ac4f01032b3b70fc7f74961cc1f2935980e5beeb0e643d3cf27c9dd985deeR1-R17): Added a new CLI using `commander` and `chalk` to initialize projects and check Docker environments.

Update to `.gitignore`:

* [`packages/doke-ui/.gitignore`](diffhunk://#diff-49d9b0772f5f522de634fd7d324f10b5c0beebc7300b9ae3836146b187af957aL18-R18): Modified the `.gitignore` file to ignore all files and directories under `.next`.