### PR TITLE
Add @types/prompts dependency, create ui command

### DIFF
--- a/packages/doke-cli/package.json
+++ b/packages/doke-cli/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@types/node": "^22.13.14",
+    "@types/prompts": "^2.4.9",
     "chalk": "^4.1.2",
     "commander": "^4.1.1",
     "cross-spawn": "^7.0.3",

--- a/packages/doke-cli/src/index.ts
+++ b/packages/doke-cli/src/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander'
 import chalk from 'chalk'
+import prompts from 'prompts'
 
 const program = new Command()
 
@@ -14,4 +15,41 @@ program
     console.log(chalk.green('✅ 프로젝트 초기화가 완료되었습니다.'))
   })
 
+program
+  .command('create ui')
+  .description('Create doke ui just-in-time')
+  .action(async () => {
+    console.log(chalk.blue('doke ui를 만드는 중 입니다.'))
+    const environment = await selectEnvironment()
+
+    if (environment === 'local') {
+      console.log(chalk.blue('로컬 환경으로 설정됩니다.'))
+    } else {
+      console.log(chalk.blue('도커 환경으로 설정됩니다.'))
+    }
+
+    console.log(chalk.green('✅ doke ui가. /path/you/want 에 생성되었습니다.'))
+  })
+
 program.parse(process.argv)
+
+export type Environment = 'local' | 'docker'
+
+export async function selectEnvironment(): Promise<Environment> {
+  const response = await prompts({
+    type: 'select',
+    name: 'environment',
+    message: 'Which environment do you want to run your project?',
+    choices: [
+      { title: 'Create local environment', value: 'local' },
+      { title: 'Create docker environment', value: 'docker' }
+    ],
+    initial: 0
+  })
+
+  if (response.environment === undefined) {
+    process.exit(1)
+  }
+
+  return response.environment
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1304,6 +1304,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prompts@npm:^2.4.9":
+  version: 2.4.9
+  resolution: "@types/prompts@npm:2.4.9"
+  dependencies:
+    "@types/node": "npm:*"
+    kleur: "npm:^3.0.3"
+  checksum: 10c0/22fe0da6807681c85e88ba283184f4be4c8a95c744ea12a638865c98c4e0c22e7f733542f6b0f1fbca02245cdc3fe84feacf9c9adf4ddd8bc98a337fd679d8d2
+  languageName: node
+  linkType: hard
+
 "@types/reflect-metadata@npm:^0.1.0":
   version: 0.1.0
   resolution: "@types/reflect-metadata@npm:0.1.0"
@@ -2301,6 +2311,7 @@ __metadata:
   resolution: "doke-cli@workspace:packages/doke-cli"
   dependencies:
     "@types/node": "npm:^22.13.14"
+    "@types/prompts": "npm:^2.4.9"
     chalk: "npm:^4.1.2"
     commander: "npm:^4.1.1"
     cross-env: "npm:^7.0.3"


### PR DESCRIPTION
This pull request introduces a new command to the `doke-cli` package, allowing users to create a UI with a specified environment. The changes include adding a new dependency, importing the necessary module, and defining the new command and its associated logic.

Key changes include:

* Added `@types/prompts` dependency in `packages/doke-cli/package.json` to support the new prompts functionality.
* Imported the `prompts` module in `packages/doke-cli/src/index.ts` to use it within the new command.
* Added a new `create ui` command to the `program` in `packages/doke-cli/src/index.ts`, which includes logic for selecting the environment and creating the UI.