### PR TITLE
Add constants for GitHub repository and directory paths

### DIFF
--- a/packages/doke-cli/src/constants/index.ts
+++ b/packages/doke-cli/src/constants/index.ts
@@ -1,0 +1,10 @@
+export const CONSTANTS = {
+  GITHUB: {
+    REPO_URL: 'https://github.com/VVSOGI/doke',
+    UI_PATH: '/packages/doke-ui'
+  },
+
+  DIRECTORY: {
+    TARGET: 'doke-ui'
+  }
+}

--- a/packages/doke-cli/src/index.ts
+++ b/packages/doke-cli/src/index.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk'
 import path from 'path'
 import { Command } from 'commander'
 import { DeploymentPrepare, GitRepositorySetup, PackageBuildManager, SelectCommand } from './modules'
+import { CONSTANTS } from './constants'
 
 const program = new Command()
 
@@ -12,7 +13,7 @@ program
   .description('Create doke ui just-in-time')
   .action(async () => {
     console.log(chalk.blue('Create doke ui'))
-    const targetDirectory = path.join(process.cwd(), 'doke-ui')
+    const targetDirectory = path.join(process.cwd(), CONSTANTS.DIRECTORY.TARGET)
     const environment = await SelectCommand.chooseEnvironment()
     const gitRepositorySetup = new GitRepositorySetup(targetDirectory)
     const packageBuildManager = new PackageBuildManager(targetDirectory)

--- a/packages/doke-cli/src/modules/GitRepositorySetup.ts
+++ b/packages/doke-cli/src/modules/GitRepositorySetup.ts
@@ -3,10 +3,11 @@ import spawn from 'cross-spawn'
 import path from 'path'
 import fs from 'fs-extra'
 import { CommandExecutor } from '../common'
+import { CONSTANTS } from '../constants'
 
 export class GitRepositorySetup {
-  private REPO_URL: string = 'https://github.com/VVSOGI/doke'
-  private FOLDER_PATH: string = '/packages/doke-ui'
+  private REPO_URL: string = CONSTANTS.GITHUB.REPO_URL
+  private FOLDER_PATH: string = CONSTANTS.GITHUB.UI_PATH
   private targetDirectory: string
   private commandExecuter: CommandExecutor
 


### PR DESCRIPTION
This pull request includes changes to centralize the configuration constants and improve code maintainability by using a single source of truth for constants. The most important changes include adding a new `CONSTANTS` object, updating file imports to use the new constants, and modifying paths and URLs to reference the constants.

Centralization of configuration constants:

* [`packages/doke-cli/src/constants/index.ts`](diffhunk://#diff-359541c2d665b60f837f296add1775319ed26afe094b611a96d1a384d13af5efR1-R10): Added a new `CONSTANTS` object to store configuration constants such as GitHub repository URL and UI path.

Code updates to use centralized constants:

* [`packages/doke-cli/src/index.ts`](diffhunk://#diff-b85ac4f01032b3b70fc7f74961cc1f2935980e5beeb0e643d3cf27c9dd985deeR5): Updated import statements to include the new `CONSTANTS` object and modified the `targetDirectory` assignment to use `CONSTANTS.DIRECTORY.TARGET`. [[1]](diffhunk://#diff-b85ac4f01032b3b70fc7f74961cc1f2935980e5beeb0e643d3cf27c9dd985deeR5) [[2]](diffhunk://#diff-b85ac4f01032b3b70fc7f74961cc1f2935980e5beeb0e643d3cf27c9dd985deeL15-R16)
* [`packages/doke-cli/src/modules/GitRepositorySetup.ts`](diffhunk://#diff-da5c3e472ea125a2530e0191e474fbe9673e0f03f610cd24e1f6b9af92d26f30R6-R10): Updated the `GitRepositorySetup` class to use `CONSTANTS.GITHUB.REPO_URL` and `CONSTANTS.GITHUB.UI_PATH` for the repository URL and folder path.