### PR TITLE
Refactor file and folder movement in DeploymentPrepare and GitRepositorySetup

### DIFF
--- a/packages/doke-cli/src/modules/DeploymentPrepare.ts
+++ b/packages/doke-cli/src/modules/DeploymentPrepare.ts
@@ -37,34 +37,24 @@ export class DeploymentPrepare {
       await fs.remove(itemPath)
     }
 
+    const nextOriginalPath = path.join(this.targetDirectory, '.next')
     const nextBackupPath = path.join(this.targetDirectory, '.next_original')
-    if (fs.existsSync(path.join(this.targetDirectory, '.next'))) {
-      await fs.move(path.join(this.targetDirectory, '.next'), nextBackupPath)
-    }
+    if (fs.existsSync(nextOriginalPath)) await fs.move(nextOriginalPath, nextBackupPath)
 
     const standalonePath = path.join(nextBackupPath, 'standalone')
-
-    if (!fs.existsSync(standalonePath)) {
-      throw new Error('.next/standalone directory not found.')
-    }
-
     const standaloneFiles = await fs.readdir(standalonePath)
     for (const file of standaloneFiles) {
       const sourcePath = path.join(standalonePath, file)
       const destPath = path.join(this.targetDirectory, file)
-
-      if (fs.existsSync(destPath)) {
-        await fs.remove(destPath)
-      }
-
-      await fs.copy(sourcePath, destPath)
+      if (fs.existsSync(destPath)) await fs.remove(destPath)
+      await fs.move(sourcePath, destPath)
     }
 
     if (fs.existsSync(nextBackupPath)) {
       const staticFiles = path.join(nextBackupPath, 'static')
       const dest = path.join(this.targetDirectory, '.next', 'static')
-      await fs.move(staticFiles, dest)
-      await fs.remove(nextBackupPath)
+      fs.moveSync(staticFiles, dest)
+      fs.removeSync(nextBackupPath)
     }
   }
 

--- a/packages/doke-cli/src/modules/GitRepositorySetup.ts
+++ b/packages/doke-cli/src/modules/GitRepositorySetup.ts
@@ -73,16 +73,14 @@ export class GitRepositorySetup {
     }
 
     const packagesPath = path.join(this.targetDirectory, this.FOLDER_PATH)
-    if (fs.existsSync(packagesPath)) {
-      const files = fs.readdirSync(packagesPath)
+    const files = fs.readdirSync(packagesPath)
 
-      files.forEach((file) => {
-        const sourcePath = path.join(packagesPath, file)
-        const destPath = path.join(this.targetDirectory, file)
-        fs.moveSync(sourcePath, destPath, { overwrite: true })
-      })
+    files.forEach((file) => {
+      const sourcePath = path.join(packagesPath, file)
+      const destPath = path.join(this.targetDirectory, file)
+      fs.moveSync(sourcePath, destPath)
+    })
 
-      fs.removeSync(path.join(this.targetDirectory, 'packages'))
-    }
+    fs.removeSync(path.join(this.targetDirectory, 'packages'))
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `DeploymentPrepare` and `GitRepositorySetup` classes in the `doke-cli` package to improve file handling and error management. The most important changes are:

Improvements to file handling:

* [`packages/doke-cli/src/modules/DeploymentPrepare.ts`](diffhunk://#diff-1ed9cd1aec4a0cf980fa85fb47f0f5e63962463a839d8e320e7222aa893eb27dR40-R57): Simplified the logic for moving and removing files by using synchronous methods (`fs.moveSync` and `fs.removeSync`) and removed redundant error checks.
* [`packages/doke-cli/src/modules/GitRepositorySetup.ts`](diffhunk://#diff-da5c3e472ea125a2530e0191e474fbe9673e0f03f610cd24e1f6b9af92d26f30L76-L88): Removed an unnecessary if-check for the existence of the `packagesPath` directory and simplified the file moving logic by removing the `overwrite` option.