### PR TITLE
Add localStart method to DeploymentPrepare

### DIFF
--- a/packages/doke-cli/package.json
+++ b/packages/doke-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doke-cli",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "keywords": [
     "nextjs",
     "doke"

--- a/packages/doke-cli/src/index.ts
+++ b/packages/doke-cli/src/index.ts
@@ -39,6 +39,7 @@ program
         await packageBuildManager.build()
         await deploymentPrepare.localDeployment()
         gitRepositorySetup.gitIntialize()
+        deploymentPrepare.localStart()
         console.log(chalk.blue('Set to local environment.'))
       } else {
         await deploymentPrepare.dockerDeployment()

--- a/packages/doke-cli/src/modules/DeploymentPrepare.ts
+++ b/packages/doke-cli/src/modules/DeploymentPrepare.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import chalk from 'chalk'
 import { CommandExecutor } from '../common'
+import { fork } from 'child_process'
 
 export class DeploymentPrepare {
   private targetDirectory: string
@@ -22,6 +23,16 @@ export class DeploymentPrepare {
     } catch (error) {
       return false
     }
+  }
+
+  public localStart = () => {
+    const target = path.join(this.targetDirectory, 'server.js')
+    fork(target, {
+      env: {
+        PORT: '3001'
+      },
+      stdio: 'inherit'
+    })
   }
 
   public localDeployment = async () => {


### PR DESCRIPTION
This pull request includes updates to the `doke-cli` package to enhance the deployment process and includes a minor version bump. The most important changes include adding a new method for local server start, updating the deployment process, and importing necessary modules.

Enhancements to deployment process:

* [`packages/doke-cli/src/index.ts`](diffhunk://#diff-b85ac4f01032b3b70fc7f74961cc1f2935980e5beeb0e643d3cf27c9dd985deeR42): Added a call to `deploymentPrepare.localStart()` to initiate the local server start after local deployment preparation.
* [`packages/doke-cli/src/modules/DeploymentPrepare.ts`](diffhunk://#diff-1ed9cd1aec4a0cf980fa85fb47f0f5e63962463a839d8e320e7222aa893eb27dR28-R37): Added a new method `localStart` to start the local server using the `fork` method from the `child_process` module.

Module imports:

* [`packages/doke-cli/src/modules/DeploymentPrepare.ts`](diffhunk://#diff-1ed9cd1aec4a0cf980fa85fb47f0f5e63962463a839d8e320e7222aa893eb27dR5): Imported the `fork` method from the `child_process` module to support the new `localStart` method.

Version update:

* [`packages/doke-cli/package.json`](diffhunk://#diff-782fd2cf1a69adb3833dc6ed89cf38e4a1637d6be0a4e3a362e5c3fad5f6b3b3L3-R3): Updated the version from `1.0.4` to `1.0.5`.