### PR TITLE
Refactor DocsWriter file path in ApiDocsGenerator constructor

### DIFF
--- a/packages/doke-nest/package.json
+++ b/packages/doke-nest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doke-nest",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Simple and beautiful API documentation generator for NestJS",
   "author": "vvsogi <vvsogi@gmail.com>",
   "license": "MIT",

--- a/packages/doke-nest/src/__test__/generators/api-docs.generator.spec.ts
+++ b/packages/doke-nest/src/__test__/generators/api-docs.generator.spec.ts
@@ -51,7 +51,7 @@ describe('Testing that ApiDocsGenerator creates json files with the correct data
     jest.spyOn(ControllerExtractor.prototype, 'extract').mockImplementation(mockControllerExtractor.extract)
     jest.spyOn(DocsWriter.prototype, 'writeDocumentation').mockImplementation(mockDocsWriter.writeDocumentation)
 
-    apiDocsGenerator = new ApiDocsGenerator(testMetadata, 'test-output-path', mockDiscoveryService)
+    apiDocsGenerator = new ApiDocsGenerator(testMetadata, mockDiscoveryService)
   })
 
   it('should generate documentation successfully', async () => {

--- a/packages/doke-nest/src/generators/api-docs.generator.ts
+++ b/packages/doke-nest/src/generators/api-docs.generator.ts
@@ -8,9 +8,9 @@ export class ApiDocsGenerator {
   private readonly writer: DocsWriter
   private readonly controllerExtractor: ControllerExtractor
 
-  constructor(metadata: ReceivedMetadata, outputPath: string, discoveryService: DiscoveryService, targetFolder?: string) {
+  constructor(metadata: ReceivedMetadata, discoveryService: DiscoveryService, targetFolder?: string) {
     this.metadata = { ...metadata, routes: [] }
-    this.writer = new DocsWriter(new FileManager(outputPath, targetFolder))
+    this.writer = new DocsWriter(new FileManager(process.cwd(), targetFolder))
     this.controllerExtractor = new ControllerExtractor(discoveryService)
   }
 


### PR DESCRIPTION
This pull request includes changes to the `doke-nest` package to update the version, modify the `ApiDocsGenerator` class, and update the corresponding test files. The most important changes include updating the version in `package.json`, modifying the `ApiDocsGenerator` constructor to remove the `outputPath` parameter, and adjusting the test cases accordingly.

Version update:
* [`packages/doke-nest/package.json`](diffhunk://#diff-7ef85e541e13f4086c3061c7bcf7c8c0921b5570f55943cf83012a668cc29b74L3-R3): Updated the version from `1.0.0` to `1.0.1`.

Constructor modification:
* [`packages/doke-nest/src/generators/api-docs.generator.ts`](diffhunk://#diff-c565110d6d571f8f2bc983aa2684425a8963dfa3a7c55223567f7c1205e5497bL11-R13): Modified the `ApiDocsGenerator` constructor to remove the `outputPath` parameter and use `process.cwd()` instead.

Test adjustments:
* [`packages/doke-nest/src/__test__/generators/api-docs.generator.spec.ts`](diffhunk://#diff-02848cecfe621e05c028a865065c11b9d599f1df06e399464484491b14829361L54-R54): Updated the test setup to reflect the changes in the `ApiDocsGenerator` constructor by removing the `outputPath` parameter.