### PR TITLE
Update doke-cli version to 1.0.6 and publish to npm

### DIFF
--- a/packages/doke-cli/package.json
+++ b/packages/doke-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doke-cli",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "keywords": [
     "nextjs",
     "doke"


### PR DESCRIPTION
This pull request includes a version bump for the `doke-cli` package. The change updates the version from `1.0.5` to `1.0.6`.

* [`packages/doke-cli/package.json`](diffhunk://#diff-782fd2cf1a69adb3833dc6ed89cf38e4a1637d6be0a4e3a362e5c3fad5f6b3b3L3-R3): Updated the version from `1.0.5` to `1.0.6`.